### PR TITLE
update mysqlclient

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,6 @@
 FROM python:2-buster
 
 RUN apt-get update && apt-get install -y default-libmysqlclient-dev python-dev libsasl2-dev libldap2-dev gcc rsyslog python-pip
-# fix for MySQL-python
-# https://github.com/DefectDojo/django-DefectDojo/issues/407#issuecomment-415862064
-RUN sed '/st_mysql_options options;/a unsigned int reconnect;' /usr/include/mysql/mysql.h -i.bkp
-RUN sed -i 's/^[^#]*imk/#&/' /etc/rsyslog.conf
-RUN echo 'input(type="imuxsock" HostName="localhost" Socket="/dev/log")' >> /etc/rsyslog.d/devlog.conf
 
 # ndcli
 COPY dimclient /dimclient/

--- a/dim/requirements.txt
+++ b/dim/requirements.txt
@@ -1,7 +1,7 @@
 # Workaround for https://github.com/pypa/setuptools/issues/940
 setuptools<34.0.0
 
-mysqlclient==1.3.8
+mysqlclient==1.4.6
 SQLAlchemy==1.1.1
 pyldap==2.4.25.1
 Werkzeug==0.11.11


### PR DESCRIPTION
The reconnect functionality was changd in the MySQL/MariaDB client
libraries. This caused the disappearance of the reconnect field in the
header file.
Adding that field back doesn't bring back the functionality. Instead
this might cause driver problems in the application.

Therefore updating the MySQL python driver is the better option.