### PR TITLE
update flask dependencies

### DIFF
--- a/dim/requirements.txt
+++ b/dim/requirements.txt
@@ -4,15 +4,15 @@ setuptools<34.0.0
 mysqlclient==1.3.8
 SQLAlchemy==1.1.1
 pyldap==2.4.25.1
-Werkzeug==0.11.11
-Flask==0.10
+Werkzeug==0.15.3
+Flask==1.0
 Flask-SQLAlchemy==2.1
-Jinja2==2.6
+Jinja2==2.10
 Flask-Script==0.5.3
 dnspython==1.15.0
 simplejson==2.6.1
 argparse==1.2.1
-requests==2.8.1
+requests==2.20.0
 pycrypto==2.6.1
 six==1.10.0
 


### PR DESCRIPTION
This brings flask at least a bit to a newer version without major
problems.

This solves the same problems as #1, #2 and #3 but also updates Jinja2 as a requirement for Flask 1.0.