### PR TITLE
[WIP] remove multithreading from pdns-output

### DIFF
--- a/dim/pdns-output/src/main/java/dim/OutputThread.java
+++ b/dim/pdns-output/src/main/java/dim/OutputThread.java
@@ -93,7 +93,7 @@ class OutputThread implements Runnable {
     /**
      * Process transaction and return true in case of success
      */
-    private boolean processTransaction(List<OutputUpdate> actions) {
+    public boolean processTransaction(List<OutputUpdate> actions) {
         if (actions == null || actions.size() == 0) {
             log.warn("Empty transaction");
             return true;


### PR DESCRIPTION
This should help for now to get pdns-output to work in a proper sequence
until a key is found that can reliably restrict events out of order.

We had the problem in production where records were created and removed
so close together, that multiple threads and processes were working on
them, that somewhere events were able to overtake the other events and
therefore get things out of order.

Now the lock should be held for the complete transaction to make sure,
things are done in order.