### PR TITLE
Fix some minor python3 issues for ndcli

### DIFF
--- a/ndcli/doc/gendoc.py
+++ b/ndcli/doc/gendoc.py
@@ -15,7 +15,7 @@ def options(opt_list):
 
 def print_options(opt_list):
     for name, help in options(opt_list):
-        print '%-23s' % name, help
+        print('%-23s' % name, help)
 
 
 def command_leaves(cmd):
@@ -28,19 +28,19 @@ def command_leaves(cmd):
 
 
 def gendoc():
-    print "Global Options\n==============\n"
+    print("Global Options\n==============\n")
     print_options(cmd.options)
 
-    print "\nCommands\n========\n"
+    print("\nCommands\n========\n")
     for leaf, chain in command_leaves(cmd):
         usage = cmd.chain_usage(chain)
-        print usage
-        print '-' * len(usage)
+        print(usage)
+        print('-' * len(usage))
         if leaf.description or leaf.help:
-            print "\n", leaf.description or leaf.help
+            print("\n", leaf.description or leaf.help)
         options = sum([c.options for c in chain[1:]], [])
         if options:
-            print "\nOptions:\n"
+            print("\nOptions:\n")
             print_options(options)
         print
 

--- a/ndcli/requirements.txt
+++ b/ndcli/requirements.txt
@@ -1,3 +1,3 @@
 python-dateutil==1.4.1
-dnspython==1.12.0
+dnspython==2.0.0
 


### PR DESCRIPTION
The man page was incomplete due to issues in gendoc.py
I've also updated the dependency dnspython to the latest version, i think version 1.12.0 from 2014 was just not compatible with python3.