### PR TITLE
fix error handling for invalid cookies

### DIFF
--- a/dim/dim/__init__.py
+++ b/dim/dim/__init__.py
@@ -33,15 +33,6 @@ class TransactionLoggingFormatter(logging.Formatter):
         return logging.Formatter.format(self, record)
 
 
-class ExpiringSessionInterface(SecureCookieSessionInterface):
-    def get_expiration_time(self, app, session):
-        if session.permanent:
-            seconds = app.config['PERMANENT_SESSION_LIFETIME']
-        else:
-            seconds = app.config['TEMPORARY_SESSION_LIFETIME']
-        return datetime.utcnow() + timedelta(seconds=seconds)
-
-
 def create_app(db_mode=None, testing=False):
     app = Flask(__name__)
 
@@ -63,8 +54,6 @@ def create_app(db_mode=None, testing=False):
         logging.error('Error parsing LAYER3DOMAIN_WHITELIST', exc_info=1)
         sys.exit(1)
     db.init_app(app)
-
-    app.session_interface = ExpiringSessionInterface()
 
     from .jsonrpc import jsonrpc
     app.register_blueprint(jsonrpc)


### PR DESCRIPTION
It happens every now and then, that cookies are being denied by the
SecureCookieSession, but we do not get a reason.
In these cases, an abort was sent, which resulted in unhandled output
and then stack traces and crashes in python handlers.

Now these error cases get reported in the same json style and should
lead to less problems on the client side.
It was tested with the available ndcli and instead of crashing it will
report the error and return a proper exit code.