### PR TITLE
dim - replace basestring with str

### DIFF
--- a/dim/dim/rrtype.py
+++ b/dim/dim/rrtype.py
@@ -202,7 +202,7 @@ def _parse_strings(value):
 
 
 def validate_strings(self, key, value):
-    if isinstance(value, basestring):
+    if isinstance(value, str):
         strings = _parse_strings(value)
     elif isinstance(value, list):
         strings = map(lambda v: _unescapify(v), value)


### PR DESCRIPTION
This is the correct solution according to
https://docs.python.org/3.0/whatsnew/3.0.html

> The builtin basestring abstract type was removed. Use str instead. The
str and bytes types don’t have functionality enough in common to warrant
a shared base class. The 2to3 tool (see below) replaces every occurrence
of basestring with str.

This fixes #19 