### PR TITLE
dim - fix group by clause for zone views

### DIFF
--- a/dim/dim/rpc.py
+++ b/dim/dim/rpc.py
@@ -1436,7 +1436,7 @@ class RPC(object):
         pattern = make_wildcard(pattern)
         qfields = []
         if fields:
-            views_stmt = db.session.query(ZoneView.zone_id, func.count('*').label('views')).group_by(ZoneView.id).subquery()
+            views_stmt = db.session.query(ZoneView.zone_id, func.count('*').label('views')).group_by(ZoneView.zone_id).subquery()
             qfields.append(views_stmt.c.views)
             groups_stmt = db.session.query(Zone.id.label('zone_id'), ZoneView.id, func.count('*').label('zone_groups'))\
                 .join(ZoneView)\


### PR DESCRIPTION
The Zoneview subquery was grouping by the zoneview id column. This would
lead to every view being counted as one.
The aim of the query was to count the views for each zone, which means
the group by needs to be on the zone_id.

Fixes #18