### PR TITLE
dim - add six dependency

### DIFF
--- a/dim/requirements.txt
+++ b/dim/requirements.txt
@@ -14,6 +14,7 @@ simplejson>=2.6.1
 argparse>=1.2.1
 requests>=2.20.0
 pycrypto>=2.6.1
+six>=1.0
 
 # Python2
 #ipaddress==1.0.17;python_version<'3.0'


### PR DESCRIPTION
Current dim relies on the six package for a couple functions. As long as
these exist in the code, we need to keep the six dependency.

It was removed in d4d1294 as porting everything to python3 was ongoing.