### PR TITLE
add custom attributes to output of list pools

### DIFF
--- a/dim/dim/models/ip.py
+++ b/dim/dim/models/ip.py
@@ -176,7 +176,7 @@ class PoolAttrName(db.Model):
     id = Column(BigInteger, primary_key=True, nullable=False)
     name = Column(String(128), nullable=False, unique=True)
 
-    reserved = ['name', 'vlan', 'description', 'version', 'created', 'modified', 'modified_by']
+    reserved = ['name', 'vlan', 'description', 'version', 'created', 'modified', 'modified_by', 'subnets']
 
 
 class PoolAttr(db.Model):

--- a/ndcli/dimcli/__init__.py
+++ b/ndcli/dimcli/__init__.py
@@ -1439,12 +1439,18 @@ class CLI(object):
     @cmd.register('list pools',
                   Argument('query', metavar='VLANID|CIDR|POOL', nargs='?'),
                   Option('o', 'can-allocate', help='limit results to pools where you can allocate'),
+                  Option('a', 'attributes',
+                         help='comma-separated list of attributes to display for each pool (default: name,vlan,subnets)',
+                         action='store',
+                         dest='attr_names',
+                         default='name,vlan,subnets'),
                   full_option,
                   script_option,
                   help='list of pools',
                   description='Displays the list of matching pools.\n\n' + query_description)
     def list_pools(self, args):
-        options = OptionDict(include_subnets=True)
+        attr_names = args.attr_names.split(',')
+        options = OptionDict(include_subnets=True,attributes=attr_names)
         options.set_if(full=args.full)
         options.set_if(can_allocate=args['can-allocate'])
         options.update(_parse_query(args.query))
@@ -1453,9 +1459,7 @@ class CLI(object):
             pool['subnets'] = ' '.join(pool['subnets'])
         if args.query:
             logger.info('Result for list pools %s', args.query)
-        _print_table(['name', {},
-                      'vlan', {'align': 'r'},
-                      'subnets', {}],
+        _print_table(sum(([a,{}] for a in attr_names), []),
                      sorted(pools, key=itemgetter('name')),
                      script=args.script)
 


### PR DESCRIPTION
This makes it possible to list custom attributes when listing pools.

The `list pools` command got a new flag `-a` or `--attributes`, the same
as with list ips, which takes a list of attributes to return.

The API endpoint ippools_list got the new parameter attributes, which
takes the list of fields to return.