### PR TITLE
ready dim-web packaging

### DIFF
--- a/.github/workflows/release_dim_web.yml
+++ b/.github/workflows/release_dim_web.yml
@@ -51,7 +51,7 @@ jobs:
       - run: mkdir -p ${HOME}/rpmbuild/SPECS
       - run: mkdir -p ${HOME}/rpmbuild/SOURCES
       - run: /bin/yum install --assumeyes epel-release
-      - run: /bin/yum install --assumeyes python36-devel python36 rpm-build python36-flask python36-xmltodict
+      - run: /bin/yum install --assumeyes python36-devel python36 rpm-build python36-flask python36-xmltodict python36-requests
       - uses: actions/download-artifact@v2
         with:
           name: dim-web-src-${{ needs.build.outputs.version }}.tar.gz
@@ -71,8 +71,10 @@ jobs:
           BuildRequires: python36-devel
           BuildRequires: python36-flask
           BuildRequires: python36-xmltodict
+          BuildRequires: python36-requests
           Requires: python36-flask
           Requires: python36-xmltodict
+          Requires: python36-requests
           Requires: python36
 
           # don't strip debug symbols, else it will all come crashing down
@@ -112,7 +114,7 @@ jobs:
       - run: mkdir -p ${HOME}/rpmbuild/SPECS
       - run: mkdir -p ${HOME}/rpmbuild/SOURCES
       - run: /bin/dnf install --assumeyes epel-release
-      - run: /bin/dnf install --assumeyes python3-devel python3 rpm-build python3-flask python3-xmltodict
+      - run: /bin/dnf install --assumeyes python3-devel python3 rpm-build python3-flask python3-xmltodict python3-requests
       - uses: actions/download-artifact@v2
         with:
           name: dim-web-src-${{ needs.build.outputs.version }}.tar.gz
@@ -132,8 +134,10 @@ jobs:
           BuildRequires: python3-devel
           BuildRequires: python3-flask
           BuildRequires: python3-xmltodict
+          BuildRequires: python3-requests
           Requires: python3-flask
           Requires: python3-xmltodict
+          Requires: python3-requests
           Requires: python3
 
           # don't strip debug symbols, else it will all come crashing down

--- a/.github/workflows/release_dim_web.yml
+++ b/.github/workflows/release_dim_web.yml
@@ -40,7 +40,66 @@ jobs:
           name: dim-web-src-${{ steps.version.outputs.version }}.tar.gz
           path: dim-web-src-${{ steps.version.outputs.version }}.tar.gz
 
-  centos:
+  centos7:
+    runs-on: ubuntu-latest
+    needs: build
+    container:
+      image: centos:centos7
+      env:
+        _VERSION: ${{ needs.build.outputs.version }}
+    steps:
+      - run: mkdir -p ${HOME}/rpmbuild/SPECS
+      - run: mkdir -p ${HOME}/rpmbuild/SOURCES
+      - run: /bin/yum install --assumeyes epel-release
+      - run: /bin/yum install --assumeyes python36-devel python36 rpm-build python36-flask
+      - uses: actions/download-artifact@v2
+        with:
+          name: dim-web-src-${{ needs.build.outputs.version }}.tar.gz
+          path: ~/rpmbuild/SOURCES/
+      - shell: sh
+        run: |
+          cat <<EOF > ${HOME}/rpmbuild/SPECS/dim-web.spec
+          Name:    python36-dim-web
+          Version: ${_VERSION}
+          Release: 1.el7
+          Summary: DNS and IP management python library
+
+          Group: application/system
+          License: MIT
+
+          Source0: dim-web-src-%{version}.tar.gz
+          BuildRequires: python36-devel
+          BuildRequires: python36-flask
+          Requires: python36-flask
+          Requires: python36
+
+          # don't strip debug symbols, else it will all come crashing down
+          %define debug_package %{nil}
+          %define __strip /bin/true
+
+          %description
+          DNS and IP management
+
+          %prep
+          %autosetup -p1 -n dim-web-%{version}
+
+          %build
+          %py3_build
+
+          %install
+          %py3_install
+
+          %files
+          %{python3_sitelib}/*
+          %{_datadir}/*
+          EOF
+      - run: rpmbuild -ba ${HOME}/rpmbuild/SPECS/dim-web.spec
+      - uses: actions/upload-artifact@v2
+        with:
+          name: python36-dim-web-${{ needs.build.outputs.version }}-1.el7.x86_64.rpm
+          path: ~/rpmbuild/RPMS/x86_64/python36-dim-web-${{ needs.build.outputs.version }}-1.el7.x86_64.rpm
+
+  centos8:
     runs-on: ubuntu-latest
     needs: build
     container:
@@ -61,7 +120,7 @@ jobs:
           cat <<EOF > ${HOME}/rpmbuild/SPECS/dim-web.spec
           Name:    python3-dim-web
           Version: ${_VERSION}
-          Release: 1
+          Release: 1.el8
           Summary: DNS and IP management python library
 
           Group: application/system
@@ -96,8 +155,8 @@ jobs:
       - run: rpmbuild -ba ${HOME}/rpmbuild/SPECS/dim-web.spec
       - uses: actions/upload-artifact@v2
         with:
-          name: python3-dim-web-${{ needs.build.outputs.version }}-1.x86_64.rpm
-          path: ~/rpmbuild/RPMS/x86_64/python3-dim-web-${{ needs.build.outputs.version }}-1.x86_64.rpm
+          name: python3-dim-web-${{ needs.build.outputs.version }}-1.el8.x86_64.rpm
+          path: ~/rpmbuild/RPMS/x86_64/python3-dim-web-${{ needs.build.outputs.version }}-1.el8.x86_64.rpm
 
   debian:
     runs-on: ubuntu-latest
@@ -131,7 +190,8 @@ jobs:
     needs:
       - build
       - debian
-      - centos
+      - centos7
+      - centos8
     steps:
       - uses: actions/checkout@v2
       - uses: actions/create-release@v1
@@ -148,7 +208,10 @@ jobs:
           name: dim-web-src-${{ needs.build.outputs.version }}.tar.gz
       - uses: actions/download-artifact@v2
         with:
-          name: python3-dim-web-${{ needs.build.outputs.version }}-1.x86_64.rpm
+          name: python36-dim-web-${{ needs.build.outputs.version }}-1.el7.x86_64.rpm
+      - uses: actions/download-artifact@v2
+        with:
+          name: python3-dim-web-${{ needs.build.outputs.version }}-1.el8.x86_64.rpm
       - uses: actions/download-artifact@v2
         with:
           name: python3-dim-web_${{ needs.build.outputs.version }}_all.deb
@@ -174,6 +237,14 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: python3-dim-web-${{ needs.build.outputs.version }}-1.x86_64.rpm
-          asset_name: python3-dim-web-${{ needs.build.outputs.version }}-1.x86_64.rpm
+          asset_path: python3-dim-web-${{ needs.build.outputs.version }}-1.el8.x86_64.rpm
+          asset_name: python3-dim-web-${{ needs.build.outputs.version }}-1.el8.x86_64.rpm
+          asset_content_type: application/octet-stream
+      - uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: python36-dim-web-${{ needs.build.outputs.version }}-1.el7.x86_64.rpm
+          asset_name: python36-dim-web-${{ needs.build.outputs.version }}-1.el7.x86_64.rpm
           asset_content_type: application/octet-stream

--- a/.github/workflows/release_dim_web.yml
+++ b/.github/workflows/release_dim_web.yml
@@ -32,8 +32,6 @@ jobs:
         working-directory: dim-web
       - run: mv dist www
         working-directory: dim-web
-      - run: ls www/**
-        working-directory: dim-web
       - run: tar --transform="s,^dim-web/,dim-web-${_version}/," -czvf "dim-web-src-${_version}.tar.gz" dim-web/setup.py dim-web/www dim-web/cas.wsgi dim-web/README.md dim-web/cas dim-web/test
         env:
           _version: ${{ steps.version.outputs.version }}
@@ -114,7 +112,6 @@ jobs:
         with:
           name: dim-web-src-${{ needs.build.outputs.version }}.tar.gz
       - run: tar -xzf dim-web-src-${{ needs.build.outputs.version }}.tar.gz
-      - run: ls -la
       - run: apt-get update
       - run: apt-get install --yes build-essential python3 python3-flask python3-setuptools python3-all dh-python debhelper devscripts
       - run: cp -vr packaging/debian/dim-web/* dim-web-${{ needs.build.outputs.version }}/

--- a/.github/workflows/release_dim_web.yml
+++ b/.github/workflows/release_dim_web.yml
@@ -51,7 +51,7 @@ jobs:
       - run: mkdir -p ${HOME}/rpmbuild/SPECS
       - run: mkdir -p ${HOME}/rpmbuild/SOURCES
       - run: /bin/yum install --assumeyes epel-release
-      - run: /bin/yum install --assumeyes python36-devel python36 rpm-build python36-flask
+      - run: /bin/yum install --assumeyes python36-devel python36 rpm-build python36-flask python36-xmltodict
       - uses: actions/download-artifact@v2
         with:
           name: dim-web-src-${{ needs.build.outputs.version }}.tar.gz
@@ -70,7 +70,9 @@ jobs:
           Source0: dim-web-src-%{version}.tar.gz
           BuildRequires: python36-devel
           BuildRequires: python36-flask
+          BuildRequires: python36-xmltodict
           Requires: python36-flask
+          Requires: python36-xmltodict
           Requires: python36
 
           # don't strip debug symbols, else it will all come crashing down
@@ -110,7 +112,7 @@ jobs:
       - run: mkdir -p ${HOME}/rpmbuild/SPECS
       - run: mkdir -p ${HOME}/rpmbuild/SOURCES
       - run: /bin/dnf install --assumeyes epel-release
-      - run: /bin/dnf install --assumeyes python3-devel python3 rpm-build python3-flask
+      - run: /bin/dnf install --assumeyes python3-devel python3 rpm-build python3-flask python3-xmltodict
       - uses: actions/download-artifact@v2
         with:
           name: dim-web-src-${{ needs.build.outputs.version }}.tar.gz
@@ -129,7 +131,9 @@ jobs:
           Source0: dim-web-src-%{version}.tar.gz
           BuildRequires: python3-devel
           BuildRequires: python3-flask
+          BuildRequires: python3-xmltodict
           Requires: python3-flask
+          Requires: python3-xmltodict
           Requires: python3
 
           # don't strip debug symbols, else it will all come crashing down

--- a/dim-web/cas.wsgi
+++ b/dim-web/cas.wsgi
@@ -1,4 +1,2 @@
 import sys
-sys.path.insert(0, '/var/lib/jenkins/dim-web/cas')
-
 from login import app as application

--- a/dim-web/cas.wsgi
+++ b/dim-web/cas.wsgi
@@ -1,2 +1,4 @@
 import sys
-from login import app as application
+from cas import login
+
+application = login.app

--- a/dim-web/setup.py
+++ b/dim-web/setup.py
@@ -7,7 +7,7 @@ from cas import version
 # So we have to split off every directory into its own data_files statement
 # with all its files just to make this work.
 data_files = []
-data_files.append(('share/dim-web', []))
+data_files.append(('share/dim-web', ['cas.wsgi', 'cas/config.py.example']))
 data_files.append(('share/dim-web/www', []))
 for dir in list(filter(lambda x: os.path.isdir(x), sorted(set(
         ['www'] + \

--- a/dim-web/setup.py
+++ b/dim-web/setup.py
@@ -20,4 +20,4 @@ setup(name='dim-web',
       packages=['cas'],
       data_files = data_files,
       version=version.VERSION,
-      install_requires=['xmltodict', 'flask'])
+      install_requires=['xmltodict', 'flask', 'requests'])

--- a/dim-web/setup.py
+++ b/dim-web/setup.py
@@ -19,4 +19,5 @@ for dir in list(filter(lambda x: os.path.isdir(x), sorted(set(
 setup(name='dim-web',
       packages=['cas'],
       data_files = data_files,
-      version=version.VERSION)
+      version=version.VERSION,
+      install_requires=['xmltodict', 'flask'])

--- a/dim-web/setup.py
+++ b/dim-web/setup.py
@@ -1,10 +1,22 @@
 from setuptools import setup
 import glob
+import os
 from cas import version
+
+# python can't handle the fact, that data_files might contain directories.
+# So we have to split off every directory into its own data_files statement
+# with all its files just to make this work.
+data_files = []
+data_files.append(('share/dim-web', []))
+data_files.append(('share/dim-web/www', []))
+for dir in list(filter(lambda x: os.path.isdir(x), sorted(set(
+        ['www'] + \
+        glob.glob('www/**', recursive=True))))):
+    data_files.append((os.path.join('share/dim-web', dir), list(filter(
+        lambda x: not os.path.isdir(x),
+        sorted(glob.glob(os.path.join(dir, '*')))))))
 
 setup(name='dim-web',
       packages=['cas'],
-      data_files=[
-          ('share/dim-web', glob.glob('www/**.*', recursive=True)),
-          ],
+      data_files = data_files,
       version=version.VERSION)


### PR DESCRIPTION
This finalizes the dim-web packaging and makes the package available for CentOS7, 8 and debian.

The package is done as a pure python package, but needs a prebuild step to build the node.js stuff.

The frontend stuff is put into /usr/share/dim-web/www, so that it can be published via a webserver.

What doesn't work is to change the configuration, as it is hardpackaged into the resulting javascript file. The build process didn't age that well too, so unless someone knows how to extract the config file from the package, sed will need to be used as a replacement.