### PR TITLE
workflow - release dim needs a fix

### DIFF
--- a/.github/workflows/release_dim.yml
+++ b/.github/workflows/release_dim.yml
@@ -56,7 +56,7 @@ jobs:
       - run: /bin/dnf install --assumeyes openldap-devel gcc python3-devel mariadb-devel git python3 rpm-build
       - run: /bin/python3 -m venv /opt/dim/
       - run: /opt/dim/bin/pip3 install -r dim/requirements.txt
-      - run: /opt/dim/bin/pip3 install dim
+      - run: /opt/dim/bin/pip3 install ./dim
       - run: mkdir /opt/dim/doc/
       - run: cp -r /tmp/dim-${{ needs.build.outputs.version }}/doc/_build/html/* /opt/dim/doc/
       - run: /bin/tar --transform="s,^opt,dim-${_VERSION}/opt," -czf "/tmp/dim-bin.tar.gz" opt
@@ -119,7 +119,7 @@ jobs:
       - run: /bin/yum install --assumeyes openldap-devel gcc python36-devel mariadb-devel git python36 rpm-build
       - run: /bin/python3.6 -m venv /opt/dim/
       - run: /opt/dim/bin/pip3.6 install -r dim/requirements.txt
-      - run: /opt/dim/bin/pip3.6 install dim
+      - run: /opt/dim/bin/pip3.6 install ./dim
       - run: mkdir /opt/dim/doc/
       - run: cp -r /tmp/dim-${{ needs.build.outputs.version }}/doc/_build/html/* /opt/dim/doc/
       - run: /bin/tar --transform="s,^opt,dim-${_VERSION}/opt," -czf "/tmp/dim-bin.tar.gz" opt


### PR DESCRIPTION
Somehow we ended up not packaging our dim but something from python
hosts.
The cause is that the relative directory operator was missing, which
caused this behavior.

*This is an import fix, as we are currently shipping the wrong thing!*