### PR TITLE
dim - fix compatibility with older ndcli clients

### DIFF
--- a/dim/dim/rpc.py
+++ b/dim/dim/rpc.py
@@ -963,7 +963,7 @@ class RPC(object):
     @readonly
     def ippool_list(self, pool=None, vlan=None, cidr=None, full=False, include_subnets=True,
                     can_allocate=None, owner=None, favorite_only=False, limit=None, offset=0,
-                    fields=False, attributes=None):
+                    fields=False, attributes=[]):
         ids = self._ippool_query(pool, vlan, cidr, can_allocate, owner)
         if favorite_only:
             ids = ids.join(FavoritePool).filter(FavoritePool.user_id == self.user.id)


### PR DESCRIPTION
When introducing the -a option to select pool attributes in
2462524 a new parameter attributes was
added to ippool_list with the default being None.

This causes a problem with older clients. Attributes is tried to be
iterated over when it is checked against the reserved keywords.
But older clients do not send the attribute parameter, which causes it
to be None and therefore causing

	ERROR - 'NoneType' object is not iterable

When we switch the default to being an empty list, the output will be as
before and even older clients can get the same output.