### PR TITLE
dim - fix pool list with attributes

### DIFF
--- a/dim-testsuite/t/pool-list-2.t
+++ b/dim-testsuite/t/pool-list-2.t
@@ -6,11 +6,14 @@ INFO - Created subnet ::/64 in layer3domain default
 WARNING - Creating zone 0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa without profile
 WARNING - Primary NS for this Domain is now localhost.
 $ ndcli list pool p
+INFO - Total free IPs: 18446744073709551615
 prio subnet gateway                 free                total
    1 ::/64          18446744073709551615 18446744073709551616
-INFO - Total free IPs: 18446744073709551615
 $ ndcli list pools p
+INFO - Result for list pools p
 name vlan subnets
 p         ::/64
-INFO - Result for list pools p
-
+$ ndcli modify pool p set attrs 'foo:bar'
+$ ndcli list pools -a 'name,subnets,foo'
+name subnets foo
+p    ::/64   bar

--- a/dim/dim/models/ip.py
+++ b/dim/dim/models/ip.py
@@ -178,7 +178,7 @@ class PoolAttrName(db.Model):
     id = Column(BigInteger, primary_key=True, nullable=False)
     name = Column(String(128), nullable=False, unique=True)
 
-    reserved = ['name', 'vlan', 'description', 'version', 'created', 'modified', 'modified_by', 'subnets']
+    reserved = ['name', 'vlan', 'description', 'version', 'created', 'modified', 'modified_by', 'layer3domain']
 
 
 class PoolAttr(db.Model):


### PR DESCRIPTION
This implementes the missing tests for #48.

When the user managed attribut list for pools was implemented it was
tested with the default field list (vlan, name), subnets and custom
attributes, but never with the standard attributes.
Needless to say, they didn't work, because they were never selected in
the query and therefore were always empty.

This commit fixes that situation and at the same time adds the missing
tests.