### PR TITLE
dim-testsuite, dim - fix delete order

### DIFF
--- a/dim-testsuite/t/ip-free-1.t
+++ b/dim-testsuite/t/ip-free-1.t
@@ -36,8 +36,8 @@ WARNING - Deleting RR 1 PTR a.de. from zone 1.1.1.in-addr.arpa
 INFO - Creating RR 1 PTR a.b.de. in zone 1.1.1.in-addr.arpa
 
 $ ndcli modify pool p free ip 1.1.1.1
-INFO - Deleting RR @ A 1.1.1.1 from zone a.de
 INFO - Deleting RR a A 1.1.1.1 from zone b.de
+INFO - Deleting RR @ A 1.1.1.1 from zone a.de
 INFO - Deleting RR 1 PTR a.b.de. from zone 1.1.1.in-addr.arpa
 INFO - Freeing IP 1.1.1.1 from layer3domain default
 

--- a/dim-testsuite/t/ip-free-3.t
+++ b/dim-testsuite/t/ip-free-3.t
@@ -24,9 +24,9 @@ $ ndcli create rr b.b.de. cname a.de.
 INFO - Creating RR b CNAME a.de. in zone b.de
 
 $ ndcli modify pool p free ip 1.1.1.1
+INFO - Deleting RR @ A 1.1.1.1 from zone a.de
 INFO - Deleting RR b CNAME a.de. from zone b.de
 INFO - Deleting RR 1 PTR a.de. from zone 1.1.1.in-addr.arpa
-INFO - Deleting RR @ A 1.1.1.1 from zone a.de
 INFO - Freeing IP 1.1.1.1 from layer3domain default
 
 $ ndcli delete container 1.0.0.0/8

--- a/dim/dim/dns.py
+++ b/dim/dim/dns.py
@@ -371,7 +371,7 @@ def delete_with_references(query, free_ips, references, user):
             done = True
         rrs = (orphaned | forward_reverse) - to_delete
         to_delete |= forward_reverse
-    for rr in to_delete:
+    for rr in sorted(to_delete, key=lambda rr: (rr.type, rr.name)):
         Messages.info("Deleting RR %s from %s" % (rr.bind_str(relative=True), rr.view))
         if free_ips and rr.ipblock_id:
             ipblocks.add(rr.ipblock_id)


### PR DESCRIPTION
When an IP was freed, the order for deleting RR records not
deterministic. Now it is and therefore the result in case of errors is
more predictable.