### PR TITLE
dim-testsuite - fix layer3domain tests

### DIFF
--- a/dim-testsuite/t/layer3domain-ip-free.t
+++ b/dim-testsuite/t/layer3domain-ip-free.t
@@ -38,8 +38,8 @@ INFO - Creating RR @ A 10.0.0.1 in zone a.de
 INFO - Creating RR 1 PTR a.de. in zone 0.0.10.in-addr.arpa view two
 
 $ ndcli modify pool p free ip 10.0.0.1
-INFO - Deleting RR 1 PTR a.de. from zone 0.0.10.in-addr.arpa view default
 INFO - Deleting RR @ A 10.0.0.1 from zone a.de
+INFO - Deleting RR 1 PTR a.de. from zone 0.0.10.in-addr.arpa view default
 INFO - Freeing IP 10.0.0.1 from layer3domain default
 
 $ ndcli delete rr a.de. a 10.0.0.1

--- a/dim-testsuite/t/layer3domain-list-ips.t
+++ b/dim-testsuite/t/layer3domain-list-ips.t
@@ -7,47 +7,47 @@ WARNING - Creating zone 0.0.10.in-addr.arpa without profile
 WARNING - Primary NS for this Domain is now localhost.
 
 $ ndcli list ips 10.0.0.0/24
-ip       status    ptr_target comment
-10.0.0.0 Reserved             
-10.0.0.1 Available            
-10.0.0.2 Available            
-10.0.0.3 Available            
-10.0.0.4 Available            
-10.0.0.5 Available            
-10.0.0.6 Available            
-10.0.0.7 Available            
-10.0.0.8 Available            
-10.0.0.9 Available            
 INFO - Result for list ips 10.0.0.0/24
 WARNING - More results available
-$ ndcli list ips p
 ip       status    ptr_target comment
-10.0.0.0 Reserved             
-10.0.0.1 Available            
-10.0.0.2 Available            
-10.0.0.3 Available            
-10.0.0.4 Available            
-10.0.0.5 Available            
-10.0.0.6 Available            
-10.0.0.7 Available            
-10.0.0.8 Available            
-10.0.0.9 Available            
+10.0.0.0 Reserved
+10.0.0.1 Available
+10.0.0.2 Available
+10.0.0.3 Available
+10.0.0.4 Available
+10.0.0.5 Available
+10.0.0.6 Available
+10.0.0.7 Available
+10.0.0.8 Available
+10.0.0.9 Available
+$ ndcli list ips p
 INFO - Result for list ips p
 WARNING - More results available
-$ ndcli list ips 10
 ip       status    ptr_target comment
-10.0.0.0 Reserved             
-10.0.0.1 Available            
-10.0.0.2 Available            
-10.0.0.3 Available            
-10.0.0.4 Available            
-10.0.0.5 Available            
-10.0.0.6 Available            
-10.0.0.7 Available            
-10.0.0.8 Available            
-10.0.0.9 Available            
+10.0.0.0 Reserved
+10.0.0.1 Available
+10.0.0.2 Available
+10.0.0.3 Available
+10.0.0.4 Available
+10.0.0.5 Available
+10.0.0.6 Available
+10.0.0.7 Available
+10.0.0.8 Available
+10.0.0.9 Available
+$ ndcli list ips 10
 INFO - Result for list ips 10
 WARNING - More results available
+ip       status    ptr_target comment
+10.0.0.0 Reserved
+10.0.0.1 Available
+10.0.0.2 Available
+10.0.0.3 Available
+10.0.0.4 Available
+10.0.0.5 Available
+10.0.0.6 Available
+10.0.0.7 Available
+10.0.0.8 Available
+10.0.0.9 Available
 
 $ ndcli create layer3domain two type vrf rd 0:2
 $ ndcli create container 10.0.0.0/8 layer3domain two
@@ -70,34 +70,37 @@ status:Static
 subnet:10.0.0.0/24
 
 $ ndcli list ips p
-ip       status    ptr_target comment
-10.0.0.0 Reserved             
-10.0.0.1 Available            
-10.0.0.2 Available            
-10.0.0.3 Available            
-10.0.0.4 Available            
-10.0.0.5 Available            
-10.0.0.6 Available            
-10.0.0.7 Available            
-10.0.0.8 Available            
-10.0.0.9 Available            
 INFO - Result for list ips p
 WARNING - More results available
-$ ndcli list ips 2
 ip       status    ptr_target comment
-10.0.0.0 Reserved             
-10.0.0.1 Available            
-10.0.0.2 Static               
-10.0.0.3 Available            
-10.0.0.4 Available            
-10.0.0.5 Available            
-10.0.0.6 Available            
-10.0.0.7 Available            
-10.0.0.8 Available            
-10.0.0.9 Available            
+10.0.0.0 Reserved
+10.0.0.1 Available
+10.0.0.2 Available
+10.0.0.3 Available
+10.0.0.4 Available
+10.0.0.5 Available
+10.0.0.6 Available
+10.0.0.7 Available
+10.0.0.8 Available
+10.0.0.9 Available
+
+$ ndcli list ips 2
 INFO - Result for list ips 2
 WARNING - More results available
+ip       status    ptr_target comment
+10.0.0.0 Reserved
+10.0.0.1 Available
+10.0.0.2 Static
+10.0.0.3 Available
+10.0.0.4 Available
+10.0.0.5 Available
+10.0.0.6 Available
+10.0.0.7 Available
+10.0.0.8 Available
+10.0.0.9 Available
 $ ndcli list ips 10.0.0.0/24
+INFO - Result for list ips 10.0.0.0/24
+WARNING - More results available
 ip       status    ptr_target comment layer3domain
 10.0.0.0 Reserved                     default
 10.0.0.0 Reserved                     two
@@ -109,20 +112,18 @@ ip       status    ptr_target comment layer3domain
 10.0.0.3 Available                    two
 10.0.0.4 Available                    default
 10.0.0.4 Available                    two
-INFO - Result for list ips 10.0.0.0/24
-WARNING - More results available
 
 $ ndcli list ips 10.0.0.0/24 layer3domain default
-ip       status    ptr_target comment
-10.0.0.0 Reserved             
-10.0.0.1 Available            
-10.0.0.2 Available            
-10.0.0.3 Available            
-10.0.0.4 Available            
-10.0.0.5 Available            
-10.0.0.6 Available            
-10.0.0.7 Available            
-10.0.0.8 Available            
-10.0.0.9 Available            
 INFO - Result for list ips 10.0.0.0/24
 WARNING - More results available
+ip       status    ptr_target comment
+10.0.0.0 Reserved
+10.0.0.1 Available
+10.0.0.2 Available
+10.0.0.3 Available
+10.0.0.4 Available
+10.0.0.5 Available
+10.0.0.6 Available
+10.0.0.7 Available
+10.0.0.8 Available
+10.0.0.9 Available

--- a/dim-testsuite/t/layer3domain-overlap-2.t
+++ b/dim-testsuite/t/layer3domain-overlap-2.t
@@ -38,8 +38,8 @@ WARNING - The name a.de. already existed, creating round robin record
 INFO - Creating RR @ A 10.0.0.1 in zone a.de
 INFO - Creating RR 1 PTR a.de. in zone 0.0.10.in-addr.arpa
 $ ndcli delete rr a.de. a 10.0.0.1 layer3domain two
-INFO - Deleting RR @ A 10.0.0.1 from zone a.de
 INFO - Deleting RR 1 PTR a.de. from zone 0.0.10.in-addr.arpa
+INFO - Deleting RR @ A 10.0.0.1 from zone a.de
 INFO - Freeing IP 10.0.0.1 from layer3domain two
 $ ndcli create rr 1.0.0.10.in-addr.arpa. ptr a.de.
 INFO - Marked IP 10.0.0.1 from layer3domain two as static
@@ -49,8 +49,8 @@ INFO - Creating RR @ A 10.0.0.1 in zone a.de
 
 $ ndcli delete pool p2 -f
 $ ndcli delete rr a.de. a 10.0.0.1 layer3domain two
-INFO - Deleting RR @ A 10.0.0.1 from zone a.de
 INFO - Deleting RR 1 PTR a.de. from zone 0.0.10.in-addr.arpa
+INFO - Deleting RR @ A 10.0.0.1 from zone a.de
 INFO - Freeing IP 10.0.0.1 from layer3domain two
 $ ndcli create rr 1.0.0.10.in-addr.arpa. ptr a.de.
 ERROR - 10.0.0.1 in layer3domain two would overlap with 10.0.0.1 in layer3domain default

--- a/dim-testsuite/t/layer3domain-overlap-3.t
+++ b/dim-testsuite/t/layer3domain-overlap-3.t
@@ -70,6 +70,9 @@ $ ndcli create zone a.de
 WARNING - Creating zone a.de without profile
 WARNING - Primary NS for this Domain is now localhost.
 $ ndcli create rr a.de. from p
+INFO - Marked IP 10.0.0.2 from layer3domain default as static
+INFO - Creating RR @ A 10.0.0.2 in zone a.de
+INFO - Creating RR 2 PTR a.de. in zone 0.0.10.in-addr.arpa view default
 created:2017-10-10 16:48:37.413313
 ip:10.0.0.2
 layer3domain:default
@@ -81,6 +84,3 @@ ptr_target:a.de.
 reverse_zone:0.0.10.in-addr.arpa
 status:Static
 subnet:10.0.0.0/24
-INFO - Marked IP 10.0.0.2 from layer3domain default as static
-INFO - Creating RR @ A 10.0.0.2 in zone a.de
-INFO - Creating RR 2 PTR a.de. in zone 0.0.10.in-addr.arpa view default

--- a/dim-testsuite/t/layer3domain-remove-subnet.t
+++ b/dim-testsuite/t/layer3domain-remove-subnet.t
@@ -52,8 +52,8 @@ ERROR - Subnet 10.0.0.0/23 from layer3domain default still contains objects
 $ ndcli modify pool p remove subnet 10.0.0.0/23 -f -c
 INFO - Deleting RR @ A 10.0.0.1 from zone a.de
 INFO - Deleting RR @ A 10.0.0.128 from zone a.de
-INFO - Deleting RR 128 PTR a.de. from zone 0.0.10.in-addr.arpa view default
 INFO - Deleting RR 1 PTR a.de. from zone 0.0.10.in-addr.arpa view default
+INFO - Deleting RR 128 PTR a.de. from zone 0.0.10.in-addr.arpa view default
 INFO - Freeing IP 10.0.0.1 from layer3domain default
 INFO - Freeing IP 10.0.0.128 from layer3domain default
 WARNING - Zone 0.0.10.in-addr.arpa view default was not deleted: The view default of the zone 0.0.10.in-addr.arpa is not empty.

--- a/dim-testsuite/t/layer3domain-rr-list.t
+++ b/dim-testsuite/t/layer3domain-rr-list.t
@@ -23,28 +23,29 @@ record zone ttl   type value                                                    
 @      a.de       A    10.0.0.1                                                        default
 @      a.de       A    10.0.0.1                                                        two
 @      a.de       TXT  "text here"
-$ ndcli list zone a.de -H
-@	a.de	86400	SOA	localhost. hostmaster.a.de. 2017101204 14400 3600 605000 86400	
-@	a.de		A	10.0.0.1	default
-@	a.de		A	10.0.0.1	two
-@	a.de		TXT	"text here"	
+$ ndcli list zone a.de
+record zone ttl   type value                                                          layer3domain
+@      a.de 86400 SOA  localhost. hostmaster.a.de. 2021041404 14400 3600 605000 86400
+@      a.de       A    10.0.0.1                                                       default
+@      a.de       A    10.0.0.1                                                       two
+@      a.de       TXT  "text here"
 
 $ ndcli list rrs *a.de
+INFO - Result for list rrs *a.de
 record zone view    ttl   type value                                                          layer3domain
 @      a.de default 86400 SOA  localhost. hostmaster.a.de. 2017092004 14400 3600 605000 86400
 @      a.de default       A    10.0.0.1                                                        default
 @      a.de default       A    10.0.0.1                                                        two
 @      a.de default       TXT  "text here"
-INFO - Result for list rrs *a.de
 $ ndcli list rrs 10.0.0.1
+INFO - Result for list rrs 10.0.0.1
 record zone view    ttl type value   layer3domain
 @      a.de default     A    10.0.0.1 default
 @      a.de default     A    10.0.0.1 two
-INFO - Result for list rrs 10.0.0.1
 $ ndcli list rrs 10.0.0.1 layer3domain two
+INFO - Result for list rrs 10.0.0.1
 record zone view    ttl type value
 @      a.de default     A    10.0.0.1
-INFO - Result for list rrs 10.0.0.1
 $ ndcli list zone a.de layer3domain two
 record zone ttl type value
 @      a.de     A    10.0.0.1

--- a/dim/dim/models/history.py
+++ b/dim/dim/models/history.py
@@ -69,7 +69,7 @@ def update_listener(mapper, connection, target):
         for change in list(changes.values()):
             if change.name == 'name':
                 make_history(target, 'renamed', {'name': change.old_value}, changed_attr=change)
-            elif change.name == 'ippool_id':
+            elif change.name == 'ippool_id' and target.pool != None:
                 make_history(target, 'set_attr', changed_attr=AttrChange('pool', target.pool.display_name, change.old_value))
             else:
                 make_history(target, 'set_attr', changed_attr=change)


### PR DESCRIPTION
This fixes all the testcases for layer3domain. It was mostly some
reordering and a small fix in the history handling for pools.

We may need to revisit that part, but for now, it should work.