### PR TITLE
dim - fix allocator for ipv6

### DIFF
--- a/dim-testsuite/runtest.py
+++ b/dim-testsuite/runtest.py
@@ -262,7 +262,6 @@ def match_table(actual_table, expected_table, actual_raw, expected_raw) -> list[
 
     result = []
     if len(actual_table) != len(expected_table):
-        print("number of lines between output and expected output differs")
         return actual_raw
     offset = 0
     for no, row in enumerate(actual_raw):

--- a/dim-testsuite/t/rr-delete-1.t
+++ b/dim-testsuite/t/rr-delete-1.t
@@ -40,16 +40,16 @@ b      a.de       AAAA  2001:db8:be:ef::1:1
 
 $ ndcli delete rr a.a.de. -n
 INFO - Dryrun mode, no data will be modified
-INFO - Deleting RR 2 PTR a.a.de. from zone 2.1.10.in-addr.arpa
 INFO - Deleting RR a A 10.1.2.2 from zone a.de
+INFO - Deleting RR 2 PTR a.a.de. from zone 2.1.10.in-addr.arpa
 INFO - Freeing IP 10.1.2.2 from layer3domain default
 
 $ ndcli delete rr a.a.de. -q
 
 $ ndcli delete rr b.a.de. -n
 INFO - Dryrun mode, no data will be modified
-INFO - Deleting RR 1.0.0.0.1.0.0.0.0.0.0.0.0.0.0.0 PTR b.a.de. from zone f.e.0.0.e.b.0.0.8.b.d.0.1.0.0.2.ip6.arpa
 INFO - Deleting RR b AAAA 2001:db8:be:ef::1:1 from zone a.de
+INFO - Deleting RR 1.0.0.0.1.0.0.0.0.0.0.0.0.0.0.0 PTR b.a.de. from zone f.e.0.0.e.b.0.0.8.b.d.0.1.0.0.2.ip6.arpa
 INFO - Freeing IP 2001:db8:be:ef::1:1 from layer3domain default
 
 $ ndcli modify pool tp1_v6 free ip 2001:db8:be:ef::1:1 -n

--- a/dim/dim/allocator.py
+++ b/dim/dim/allocator.py
@@ -1,5 +1,4 @@
 import logging
-import math
 import random
 from collections import namedtuple
 from itertools import islice, groupby
@@ -116,7 +115,7 @@ def free_ranges(parent_query):
                 # We need to split the range if we had no children, otherwise we
                 # could try to allocate a child with the same prefix, which is not
                 # possible
-                mid = math.floor((range_end + 1 + range_start) / 2)
+                mid = ((range_end - range_start + 1) % 2 + range_start)
                 ranges.append([range_start, mid - 1])
                 ranges.append([mid, range_end])
             else:


### PR DESCRIPTION
When the IPv6 split was computed the datatype changed to float. This
caused the loss of the smallest bits because of how float was
implemented.
Using integer division this problem was partially circumvented. But then
the addition of two IPv6 addresses as integers will cause the result to
be of type long. This is a problem as integer division doesn't seem to be
implemented for long. The result was always 0, but didn't cause a type
error.

This means we needed to change the formula a bit, to run the calculation
with smaller numbers.