### PR TITLE
dim - pin dependencies

### DIFF
--- a/dim/requirements.txt
+++ b/dim/requirements.txt
@@ -2,16 +2,15 @@
 setuptools<34.0.0
 
 mysqlclient>=1.4.6
-SQLAlchemy>=1.1.1
+SQLAlchemy~=1.4
 pyldap>=2.4.25.1
 Werkzeug>=0.15.3
-Flask>=1.0
-Flask-SQLAlchemy>=2.1
-Jinja2>=2.10.1
-Flask-Script>=0.5.3
-dnspython>=1.15.0
-simplejson>=2.6.1
-argparse>=1.2.1
-requests>=2.20.0
-pycryptodome>=3.10.1
-six>=1.0
+Flask~=1.1
+Flask-SQLAlchemy~=2.5
+Jinja2~=2.11
+Flask-Script~=2.0
+dnspython~=2.1
+simplejson~=3.17
+requests~=2.25
+pycryptodome~=3.10
+six


### PR DESCRIPTION
Pin the dependencies the avoid problems because of random dependency
updates.
The two most important updates in the last couple weeks are SQLALchemy
and Flask, which are currently breaking dim.