### PR TITLE
do not use f-strings

### DIFF
--- a/dim-testsuite/runtest.py
+++ b/dim-testsuite/runtest.py
@@ -364,7 +364,7 @@ def run_test(testfile, outfile, stop_on_error=False, auto_pdns_check=False):
 
                         ok = output == expected_result
                         if not ok:
-                            print(f"results didn't match:\nexpected: {expected_result}\nbut got: {output}")
+                            print("results didn't match:\nexpected: {}\nbut got: {}".format(expected_result, output))
                         if auto_pdns_check and not check_pdns_output(line, out):
                             ok = False
                     else:

--- a/dim/dim/models/dns.py
+++ b/dim/dim/models/dns.py
@@ -549,9 +549,9 @@ def dnskey_tag(rdata):
 
 def ds_hash(owner, rdata, digest_function):
     if type(owner) != bytes:
-        raise TypeError(f"owner must be of type bytes, got {type(owner)}")
+        raise TypeError("owner must be of type bytes, got {}".format(type(owner)))
     if type(rdata) != bytes:
-        raise TypeError(f"rdata must be of type bytes, got {type(owner)}")
+        raise TypeError("rdata must be of type bytes, got {}".format(type(rdata)))
 
     parts = owner.lower().split(b'.')
     canon = []

--- a/ndcli/dimcli/cliparse.py
+++ b/ndcli/dimcli/cliparse.py
@@ -467,7 +467,7 @@ class Command(object):
                 usage += ' [<subcommand>]'
             else:
                 usage += ' <subcommand>'
-        print(f"Usage: {usage}")
+        print("Usage: {}".format(usage))
         if last.description or last.help:
             print("\n", last.description or last.help)
 


### PR DESCRIPTION
Ensure compatibility with Debian 9 (which ships with Python 3.5):
* use `.format()` instead of `f""`
f-strings were added in 3.6 and are not supported in earlier versions
https://docs.python.org/3/whatsnew/3.6.html#whatsnew36-pep498

While adjusting the code,I noticed one statement used the wrong variable:
* fix error message for type mismatch of rdata (models/dns)