### PR TITLE
use transaction wrapper's dryrun for dim/ldap_sync and add deletion thresholds

### DIFF
--- a/dim/dim/defaults.py
+++ b/dim/dim/defaults.py
@@ -21,6 +21,10 @@ LDAP_DEPARTMENT_BASE = ""
 LDAP_OPT_TIMEOUT = 60
 LDAP_OPT_TIMELIMIT = 60
 LDAP_OPT_NETWORK_TIMEOUT = 60
+# thresholds for deletions during sync, to help catch configuration/ldap issues
+LDAP_SYNC_DELETION_THRESHOLD_USERS = -1
+LDAP_SYNC_DELETION_THRESHOLD_DEPARTMENTS = -1
+
 
 # Set SECRET_KEY to a random string
 # The security of this application is compromised if SECRET_KEY is leaked

--- a/dim/dim/ldap_sync.py
+++ b/dim/dim/ldap_sync.py
@@ -64,7 +64,8 @@ class LDAP(object):
                                name=dept['attributes']['cn'][0])
                     for dept in res]
 
-def sync_departments(ldap: LDAP, dry_run: bool = False):
+
+def sync_departments(ldap: LDAP):
     '''Update the department table'''
     db_departments = Department.query.all()
     ldap_departments = dict((dep.department_number, dep) for dep in ldap.departments())
@@ -74,18 +75,15 @@ def sync_departments(ldap: LDAP, dry_run: bool = False):
         if ldep:
             if ddep.name != ldep.name:
                 logging.info('Renaming department %s to %s' % (ddep.name, ldep.name))
-                if not dry_run:
-                    ddep.name = ldep.name
+                ddep.name = ldep.name
             del ldap_departments[ddep.department_number]
         else:
             logging.info('Deleting department %s' % ddep.name)
-            if not dry_run:
-                db.session.delete(ddep)
+            db.session.delete(ddep)
     # handle new departments
     for ldep in list(ldap_departments.values()):
         logging.info('Creating department %s' % ldep.name)
-        if not dry_run:
-            db.session.add(ldep)
+        db.session.add(ldep)
 
 
 def log_stdout(message: str):
@@ -93,7 +91,7 @@ def log_stdout(message: str):
     print(message)
 
 
-def sync_users(ldap: LDAP, dry_run: bool = False):
+def sync_users(ldap: LDAP):
     '''Update the user table ldap_cn, ldap_uid and department_number fields'''
     db_users = User.query.all()
     ldap_users = dict((u.username, u)
@@ -106,38 +104,35 @@ def sync_users(ldap: LDAP, dry_run: bool = False):
                              (db_user.username,
                               db_user.ldap_cn,
                               ldap_user.ldap_cn))
-                if not dry_run:
-                    db_user.ldap_cn = ldap_user.ldap_cn
+                db_user.ldap_cn = ldap_user.ldap_cn
             if db_user.department_number != ldap_user.department_number:
                 logging.info('User %s moved from department_number %s to %s' %
                              (db_user.username,
                               db_user.department_number,
                               ldap_user.department_number))
-                if not dry_run:
-                    db_user.department_number = ldap_user.department_number
+                db_user.department_number = ldap_user.department_number
             if db_user.ldap_uid != ldap_user.ldap_uid:
                 logging.info('User %s changed uid from %s to %s' %
                              (db_user.username,
                               db_user.ldap_uid,
                               ldap_user.ldap_uid))
-                if not dry_run:
-                    db_user.ldap_uid = ldap_user.ldap_uid
+                db_user.ldap_uid = ldap_user.ldap_uid
         elif db_user.ldap_uid:
             log_stdout('Deleting user %s' % db_user.username)
-            if not dry_run:
-                db.session.delete(db_user)
+            db.session.delete(db_user)
 
 
 @time_function
 @transaction
-def ldap_sync(dry_run: bool = False):
+def ldap_sync():
+    '''Update Users, Group, and Departments from LDAP'''
     ldap = LDAP()
 
     if sys.stdout.isatty():
         logging.getLogger().addHandler(logging.StreamHandler(sys.stderr))
 
-    sync_departments(ldap, dry_run)
-    sync_users(ldap, dry_run)
+    sync_departments(ldap)
+    sync_users(ldap)
 
     # Synchronize group members
     ldap_users = {}  # map department_number to list of usernames
@@ -159,8 +154,7 @@ def ldap_sync(dry_run: bool = False):
                     # DIM-209 append id to department name to generate an unique user group name
                     new_name += '_%s' % dept.department_number
                 logging.info('Renaming group %s to %s' % (group.name, new_name))
-                if not dry_run:
-                    group.name = new_name
+                group.name = new_name
             ldap_users[group.department_number] = \
                 [u.username for u in ldap.users('departmentNumber=%s' % dept.department_number)]
     # Remove all users added by a ldap query that are no longer present in the group
@@ -169,8 +163,7 @@ def ldap_sync(dry_run: bool = False):
            membership.user.username not in ldap_users[membership.group.department_number]:
             logging.info('User %s was removed from group %s' %
                          (membership.user.username, membership.group.name))
-            if not dry_run:
-                membership.group.remove_user(membership.user)
+            membership.group.remove_user(membership.user)
     # Add new users to groups
     for group in Group.query.filter(Group.department_number != None).all():  # noqa
         group_users = set([u.username for u in group.users])
@@ -184,13 +177,11 @@ def ldap_sync(dry_run: bool = False):
                                 ldap_uid=lu.ldap_uid,
                                 ldap_cn=lu.ldap_cn,
                                 department_number=lu.department_number)
-                    if not dry_run:
-                        db.session.add(user)
-                        db.session.add(GroupMembership(user=user, group=group, from_ldap=True))
+                    db.session.add(user)
+                    db.session.add(GroupMembership(user=user, group=group, from_ldap=True))
                     group_users.add(username)
                     logging.info('User %s was created and added to group %s', username, group.name)
             else:
                 logging.info('User %s was added to group %s', username, group.name)
-                if not dry_run:
-                    db.session.add(GroupMembership(user=user, group=group, from_ldap=True))
+                db.session.add(GroupMembership(user=user, group=group, from_ldap=True))
                 group_users.add(username)

--- a/dim/manage_dim
+++ b/dim/manage_dim
@@ -54,15 +54,17 @@ def update_validity():
 
 
 @manager.option('-n', '--dry-run', dest='dryrun', action='store_true')
-def ldap_sync(dryrun):
+@manager.option('-f', '--ignore-deletion-threshold', dest='ignore_deletion_threshold', action='store_true')
+def ldap_sync(dryrun, ignore_deletion_threshold):
     '''Update Users, Group, and Departments from LDAP'''
-    dim.ldap_sync.ldap_sync(dryrun=dryrun)
+    dim.ldap_sync.ldap_sync(dryrun=dryrun, ignore_deletion_threshold=ignore_deletion_threshold)
 
 
 @manager.option('-n', '--dry-run', dest='dryrun', action='store_true')
-def sync_ldap(dryrun):
+@manager.option('-f', '--ignore-deletion-threshold', dest='ignore_deletion_threshold', action='store_true')
+def sync_ldap(dryrun, ignore_deletion_threshold):
     '''Update Users, Group, and Departments from LDAP'''
-    dim.ldap_sync.ldap_sync(dryrun=dryrun)
+    dim.ldap_sync.ldap_sync(dryrun=dryrun, ignore_deletion_threshold=ignore_deletion_threshold)
 
 
 @manager.command

--- a/dim/manage_dim
+++ b/dim/manage_dim
@@ -53,16 +53,16 @@ def update_validity():
         dim.models.db.session.commit()
 
 
-@manager.option('-n', '--dry-run', dest='dry_run', action='store_true')
-def ldap_sync(dry_run):
+@manager.option('-n', '--dry-run', dest='dryrun', action='store_true')
+def ldap_sync(dryrun):
     '''Update Users, Group, and Departments from LDAP'''
-    dim.ldap_sync.ldap_sync(dry_run=dry_run)
+    dim.ldap_sync.ldap_sync(dryrun=dryrun)
 
 
-@manager.option('-n', '--dry-run', dest='dry_run', action='store_true')
-def sync_ldap(dry_run):
+@manager.option('-n', '--dry-run', dest='dryrun', action='store_true')
+def sync_ldap(dryrun):
     '''Update Users, Group, and Departments from LDAP'''
-    dim.ldap_sync.ldap_sync(dry_run=dry_run)
+    dim.ldap_sync.ldap_sync(dryrun=dryrun)
 
 
 @manager.command


### PR DESCRIPTION
Use dry-run functionality provided by [dim/transaction.py#91](https://github.com/1and1/dim/blob/6a4b7d9d3cdaa39d95e29ae31c557b533e268a10/dim/dim/transaction.py#L91) instead of `if`s in `ldap_sync.py`
Add thresholds for deletions to catch cases like misconfiguration and issues with the LDAP server.

- [x] transaction dryrun
- [x] deletion threshold for users
- [x] deletion threshold for departments
- [x] update documentation/default configuration

resolves #89 