### PR TITLE
RPM spec file for pdns-output

### DIFF
--- a/packaging/RPM/pdns-output/.gitignore
+++ b/packaging/RPM/pdns-output/.gitignore
@@ -1,0 +1,4 @@
+BUILD/
+RPMS/
+SRPMS/
+SOURCES/*tar.gz

--- a/packaging/RPM/pdns-output/SOURCES/pdns-output.properties
+++ b/packaging/RPM/pdns-output/SOURCES/pdns-output.properties
@@ -1,0 +1,24 @@
+# dim database connection parameters
+db.serverName=127.0.0.1
+db.portNumber=3306
+db.databaseName=dim
+db.user=dim_user
+db.password=dim_pass
+ 
+# Timeout in seconds for getting the pdns_poller lock which prevents multiple pdns-output instances from running
+lockTimeout=120
+ 
+# Delay in seconds used when polling the dim outputupdate table
+pollDelay=1
+ 
+# Delay in seconds before retrying a failed update
+retryInterval=60
+ 
+# Debug option to print to stdout transaction ids after processing them
+printTxn=false
+ 
+# Max size of a sql query in bytes
+# should be less than the configured max_allowed_packet in mysql
+maxQuerySize=4000000
+ 
+useNativeCrypto=true

--- a/packaging/RPM/pdns-output/SOURCES/pdns-output.service
+++ b/packaging/RPM/pdns-output/SOURCES/pdns-output.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=DIM to PowerDNS DB
+After=network.target mysql.target
+ 
+[Service]
+Type=simple
+ExecStart=/bin/java -jar /usr/libexec/pdns-output.jar
+Restart=on-failure
+StartLimitInterval=0
+PrivateTmp=true
+PrivateDevices=true
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE CAP_SETGID CAP_SETUID CAP_CHOWN CAP_SYS_CHROOT
+NoNewPrivileges=true
+ProtectSystem=full
+ProtectHome=true
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+LimitNOFILE=40000
+ 
+[Install]
+WantedBy=multi-user.target

--- a/packaging/RPM/pdns-output/pdns-output.spec
+++ b/packaging/RPM/pdns-output/pdns-output.spec
@@ -1,0 +1,54 @@
+Name:       pdns-output
+Version:    4.0.0
+Release:    1
+Summary:    DIM PDNS Output Service
+License:    MIT
+URL:        https://github.com/1and1/dim
+Requires:   java-1.8.0-openjdk-headless
+BuildRequires:   java-1.8.0-openjdk-devel
+
+Source0: dim-%{version}.tar.gz
+Source1: pdns-output.properties
+Source2: pdns-output.service
+
+%define debug_package %{nil}
+
+%description
+Connects to DIM Database and reads configuration of outputs and events for PowerDNS Databases.
+
+%prep
+%setup -q -n dim-%{version}
+
+%build
+pushd jdnssec-dnsjava
+ls
+ls ..
+../gradlew build -x test
+../gradlew publishToMavenLocal
+popd
+pushd jdnssec-tools
+../gradlew build -x test
+../gradlew publishToMavenLocal
+popd
+pushd gmp-rsa
+../gradlew build -x test
+../gradlew publishToMavenLocal
+popd
+pushd pdns-output
+../gradlew build -x test
+../gradlew publishToMavenLocal
+popd
+
+%install
+install -Dm 644 pdns-output/build/libs/pdns-output-4.0.0-all.jar %{buildroot}%{_libexecdir}/pdns-output.jar
+install -Dm 644 %{SOURCE1} %{buildroot}%{_sysconfdir}/dim/pdns-output.properties
+install -Dm 644 %{SOURCE2} %{buildroot}%{_unitdir}/pdns-output.service
+
+%files
+%{_libexecdir}/pdns-output.jar
+%{_sysconfdir}/dim/pdns-output.properties
+%{_unitdir}/pdns-output.service
+
+%changelog
+* Thu Jul 15 2021 Christoph Maser <christoph.maser@gmail.com> - 4.0.0
+- Initial package


### PR DESCRIPTION
related to #71

steps to build

```
cd packaging/RPM/pdns-output
_version="4.0.0";  tar --transform="s,^dim/,dim-${_version}/," -czvf ./SOURCES/dim-${_version}.tar.gz  ${dim_source_dir}
rpmbuild --define="_topdir $(pwd)" -bs pdns-output.spec
mock -vr epel-8-x86_64 --enable-network --rebuild ./SRPMS/pdns-output-4.0.0-1.src.rpm
```