### PR TITLE
Build pdns-output in github actions

### DIFF
--- a/.github/workflows/build_pdns-output.yml
+++ b/.github/workflows/build_pdns-output.yml
@@ -1,0 +1,35 @@
+name: Build PDNS-Output
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 8
+      uses: actions/setup-java@v2
+      with:
+        distribution: 'adopt'
+        java-version: 8
+    - name: Build jdnssec-dnsjava
+      run: gradle build -x test && gradle publishToMavenLocal
+      working-directory: jdnssec-dnsjava
+    - name: Build jdnssec-tools
+      run: gradle build -x test && gradle publishToMavenLocal
+      working-directory: jdnssec-tools
+    - name: Build gmp-rsa
+      run: gradle build -x test && gradle publishToMavenLocal
+      working-directory: gmp-rsa
+    - name: Build pdns-output
+      run: gradle shadowJar -x test
+      working-directory: pdns-output
+      
+    - uses: actions/upload-artifact@v2
+      with:
+        name: pdns-output
+        path: pdns-output/build/libs/pdns-output*-all.jar

--- a/.github/workflows/build_pdns-output.yml
+++ b/.github/workflows/build_pdns-output.yml
@@ -1,10 +1,6 @@
 name: Build PDNS-Output
 
-on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+on: [ push, pull_request ]
 
 jobs:
   build:


### PR DESCRIPTION
Automatic building of pdns-output.
The PR just contains the building and uploading of an artifact.
I've also provided #107 which runs the tests that are included in the project. I prefer the alternative in #107.

One next step could be adding that to release.