### PR TITLE
ndcli: include manpage in debian package

### DIFF
--- a/packaging/debian/ndcli/debian/ndcli.manpages
+++ b/packaging/debian/ndcli/debian/ndcli.manpages
@@ -1,0 +1,1 @@
+doc/_build/man/ndcli.1


### PR DESCRIPTION
add `.manpages` file referencing ndcli's manpage,
so debhelper will include it in the debian package

resolves #102 