### PR TITLE
ndcli,dim-testsuite: add support for NDCLI_USERNAME and NDCLI_SERVER

### DIFF
--- a/dim-testsuite/Makefile
+++ b/dim-testsuite/Makefile
@@ -3,6 +3,8 @@ VDIR          ?= virtual_env
 ODIR          ?= out
 VPIP          ?= ${VDIR}/bin/pip3
 VPYTHON       ?= ${VDIR}/bin/python3
+NDCLI_USERNAME ?= admin
+NDCLI_SERVER   ?= http://localhost:5000
 
 all: install db test
 	mkdir ${VDIR}
@@ -24,6 +26,9 @@ db:
 test:
 	-mkdir ${ODIR}
 	${VDIR}/bin/manage_db clear
-	PATH="${VDIR}/bin:${PATH}" TEST_OUTPUT_DIR="${ODIR}" ${VPYTHON} runtest.py -d
+	PATH="${VDIR}/bin:${PATH}" \
+			 TEST_OUTPUT_DIR="${ODIR}" \
+			 NDCLI_USERNAME="${NDCLI_USERNAME}" \
+			 NDCLI_SERVER="${NDCLI_SERVER}" ${VPYTHON} runtest.py -d
 
 .PHONY: db test install clean

--- a/dim-testsuite/runtest.py
+++ b/dim-testsuite/runtest.py
@@ -21,6 +21,7 @@ import os.path
 import re
 import shlex
 import sys
+import urllib
 from io import StringIO
 from itertools import zip_longest
 from subprocess import Popen, PIPE, DEVNULL, STDOUT
@@ -380,7 +381,11 @@ def run_test(testfile, outfile, stop_on_error=False, auto_pdns_check=False):
 
 if __name__ == '__main__':
     # start the server process
-    server = Popen(['manage_dim', 'runserver'], stderr=DEVNULL, stdout=DEVNULL)
+    parsed =urllib.parse.urlparse(os.getenv('NDCLI_SERVER', 'http://localhost:5000'))
+    host = parsed.hostname
+    port = parsed.port
+
+    server = Popen(['manage_dim', 'runserver', '--port', str(port), '--host', host], stderr=DEVNULL, stdout=DEVNULL)
 
     stop_on_error = False
     auto_pdns_check = False


### PR DESCRIPTION
By adding environment variables NDCLI_USERNAME and NDCLI_SERVER ndcli
can not be configured to use other servers or usernames via environment
variables too.

NDCLI_COOKIEPATH was also added if the cookie path for the same user
needs to be adjusted.

The default cookiepath was changed from ~/.ndcli.cookie to
~/.ndcli.cookie.{ username }.
Cookies are already stored per hostname in the cookie store, but there
is no distinction between different usernames. Therefore it was possible
that for a different user the same cookie was used.
By changing the default, each username now gets its own cookie store and
mix ups do not happen anymore.

There is the drawback for people who test with many different users,
thay they will accumulate many different files now.

Another problem is, that this change brough to light a whole bunch of
new errors in the dim testsuite.
Some tests changed between different users, which didn't work properly
in the past. These are now all failing as sometimes users are not
created or the wrong user is used for the test.

The testsuite was adjusted to support the new flags with the name names.
Using NDCLI_USERNAME and NDCLI_SERVER for the default tests is working.