### PR TITLE
allow modifying the type of layer3domains

### DIFF
--- a/dim-testsuite/t/layer3domain-create.t
+++ b/dim-testsuite/t/layer3domain-create.t
@@ -22,3 +22,8 @@ $ ndcli create layer3domain test type vrf rd 256:256
 $ ndcli create pool somepool layer3domain test
 $ ndcli delete layer3domain test
 ERROR - layer3domain test still contains pools
+$ ndcli create layer3domain test2 type customtype
+$ ndcli create layer3domain test3 type customtype rd 22:22
+ERROR - Type customtype does not support attributes
+$ ndcli create layer3domain test4 type vrf
+ERROR - Type vrf requires a rd

--- a/dim-testsuite/t/layer3domain-modify-type.t
+++ b/dim-testsuite/t/layer3domain-modify-type.t
@@ -1,0 +1,8 @@
+$ ndcli create layer3domain test type vrf rd 0:0
+$ ndcli modify layer3domain test set type test
+$ ndcli list layer3domains
+type  name    properties comment
+vrf   default rd:8560:1  
+test  test
+$ ndcli modify layer3domain test set type vrf rd 256:256
+$ ndcli delete layer3domain test

--- a/dim/dim/rpc.py
+++ b/dim/dim/rpc.py
@@ -303,11 +303,12 @@ class RPC(object):
         self.user.can_network_admin()
         if Layer3Domain.query.filter_by(name=name).count():
             raise AlreadyExistsError("A layer3domain named '%s' already exists" % name)
-        if type not in Layer3Domain.TYPES:
-            raise InvalidParameterError('Type must be one of: %s' % ' '.join(list(Layer3Domain.TYPES.keys())))
-        for attr_name in Layer3Domain.TYPES[type]:
-            if options.get(attr_name) is None:
-                raise InvalidParameterError('Type %s requires a %s' % (type, attr_name))
+        if type in Layer3Domain.TYPES:
+            for attr_name in Layer3Domain.TYPES[type]:
+                if options.get(attr_name) is None:
+                    raise InvalidParameterError('Type %s requires a %s' % (type, attr_name))
+        elif type not in Layer3Domain.TYPES and len(options) > 0:
+            raise InvalidParameterError('Type %s does not support attributes' % (type))
 
         layer3domain = Layer3Domain(name=name, type=type, comment=comment)
         if type == Layer3Domain.VRF:

--- a/dim/dim/rpc.py
+++ b/dim/dim/rpc.py
@@ -327,6 +327,14 @@ class RPC(object):
         if layer3domain.type == Layer3Domain.VRF:
             set_rd(layer3domain, rd)
 
+    @updating
+    def layer3domain_set_type(self, layer3domain, type, rd=None):
+        self.user.can_network_admin()
+        layer3domain = get_layer3domain(layer3domain)
+        layer3domain.type = type
+        if layer3domain.type == Layer3Domain.VRF:
+            set_rd(layer3domain, rd)
+
     @readonly
     def layer3domain_get_attrs(self, layer3domain):
         layer3domain = get_layer3domain(layer3domain)

--- a/ndcli/dimcli/__init__.py
+++ b/ndcli/dimcli/__init__.py
@@ -1005,6 +1005,17 @@ class CLI(object):
         options.set_if(rd=args.rd)
         self.client.layer3domain_set_attrs(args.layer3domain, **options)
 
+    @cmd.register('modify layer3domain set type',
+                    Argument('type'),
+                    Group(Token('rd'), Argument('rd'), nargs='?'))
+    def modify_layer3domain_set_type(self, args):
+        '''
+        Set the type for LAYER3DOMAIN.
+        '''
+        options = OptionDict()
+        options.set_if(rd=args.rd)
+        self.client.layer3domain_set_type(args.layer3domain, args.type, **options)
+
     @cmd.register('delete layer3domain',
                   layer3domain_arg)
     def delete_layer3domain(self, args):
@@ -1035,7 +1046,7 @@ class CLI(object):
                       'comment', {}],
                      [{'name': l['name'],
                        'type': l['type'],
-                       'properties': ' '.join('%s:%s' % (k, v) for k, v in l['properties'].items()),
+                       'properties': ' '.join('%s:%s' % (k, v) for k, v in l['properties'].items()) if 'properties' in l else '',
                        'comment': l['comment']} for l in self.client.layer3domain_list()],
                      script=args.script)
 

--- a/ndcli/dimcli/__init__.py
+++ b/ndcli/dimcli/__init__.py
@@ -978,8 +978,7 @@ class CLI(object):
                   Argument('name'),
                   Token('type'),
                   Argument('type'),
-                  Token('rd'),
-                  Argument('rd'),
+                  Group(Token('rd'), Argument('rd'), nargs='?'),
                   Group(Token('comment'), Argument('comment'), nargs='?'))
     def create_layer3domain(self, args):
         options = OptionDict()


### PR DESCRIPTION
This adds the functionality to modify a layer3domain. The type can be
any string as it was until now.
The route distinguisher value is kept as is and when changing back to
vrf can still be set.

This should fix #119