### PR TITLE
adjust error message when deleting a layer3domain

### DIFF
--- a/dim-testsuite/t/layer3domain-create.t
+++ b/dim-testsuite/t/layer3domain-create.t
@@ -14,3 +14,11 @@ vrf  default rd:8560:1
 vrf  max     rd:65535:65535
 vrf  min     rd:0:0
 $ ndcli delete layer3domain max
+$ ndcli create container 192.168.0.0/16 layer3domain min
+INFO - Creating container 192.168.0.0/16 in layer3domain min
+$ ndcli delete layer3domain min
+ERROR - layer3domain min still contains objects
+$ ndcli create layer3domain test type vrf rd 256:256
+$ ndcli create pool somepool layer3domain test
+$ ndcli delete layer3domain test
+ERROR - layer3domain test still contains pools

--- a/dim/dim/rpc.py
+++ b/dim/dim/rpc.py
@@ -355,6 +355,8 @@ class RPC(object):
     def layer3domain_delete(self, name):
         self.user.can_network_admin()
         layer3domain = get_layer3domain(name)
+        if Pool.query.filter_by(layer3domain=layer3domain).count() > 0:
+            raise DimError('layer3domain %s still contains pools' % layer3domain.name)
         if Ipblock.query.filter_by(layer3domain=layer3domain).count() > 0:
             raise DimError('layer3domain %s still contains objects' % layer3domain.name)
         db.session.delete(layer3domain)


### PR DESCRIPTION
Now instead of a SQL error a custom error message pointing to the actual
problem is raised.

This fixes #120 