### PR TITLE
add option to view all containers in all layer3domains

### DIFF
--- a/dim-testsuite/t/container-layer3domain.t
+++ b/dim-testsuite/t/container-layer3domain.t
@@ -30,3 +30,16 @@ $ ndcli list containers layer3domain one
 $ ndcli list containers layer3domain one 1.0.0.0/8
 1.0.0.0/8 (Container) c:d
   1.0.0.0/8 (Available)
+$ ndcli create layer3domain two type vrf rd 0:3
+$ ndcli create container 2.0.0.0/8 layer3domain two
+INFO - Creating container 2.0.0.0/8 in layer3domain two
+$ ndcli list containers layer3domain all
+layer3domain: default
+
+layer3domain: one
+1.0.0.0/8 (Container) c:d
+  1.0.0.0/8 (Available)
+
+layer3domain: two
+2.0.0.0/8 (Container)
+  2.0.0.0/8 (Available)

--- a/ndcli/dimcli/__init__.py
+++ b/ndcli/dimcli/__init__.py
@@ -1563,12 +1563,21 @@ class CLI(object):
                 print('  ' * level + '%s %s' % (node['ip'], ' '.join(attributes)))
                 if 'children' in node:
                     print_tree(node['children'], level + 1)
-        options = OptionDict(include_messages=True)
-        options.set_if(container=args.container)
-        options.set_if(layer3domain=args.layer3domain)
-        result = self.client.container_list(**options)
-        _print_messages(result)
-        print_tree(result['containers'], 0)
+        layer3domains = [args.layer3domain]
+        if args.layer3domain == "all":
+            layer3domains = [l['name'] for l in self.client.layer3domain_list()]
+
+        for idx, layer3domain in enumerate(layer3domains):
+            if len(layer3domains) > 1:
+                if idx > 0:
+                    print()
+                print('layer3domain: ' + layer3domain)
+            options = OptionDict(include_messages=True)
+            options.set_if(container=args.container)
+            options.set_if(layer3domain=layer3domain)
+            result = self.client.container_list(**options)
+            _print_messages(result)
+            print_tree(result['containers'], 0)
 
     @cmd.register('list ips',
                   Argument('query', metavar='VLANID|CIDR|POOL'),


### PR DESCRIPTION
Add keyword 'all' to layer3domain of 'list containers' to view all
containers in all layer3domains. It is still possible to view only the
containers of a single layer3domain.

Fixes #125