### PR TITLE
dim - do not allow layer3domain called all

### DIFF
--- a/dim-testsuite/t/layer3domain-create.t
+++ b/dim-testsuite/t/layer3domain-create.t
@@ -22,3 +22,5 @@ $ ndcli create layer3domain test type vrf rd 256:256
 $ ndcli create pool somepool layer3domain test
 $ ndcli delete layer3domain test
 ERROR - layer3domain test still contains pools
+$ ndcli create layer3domain all type vrf rd 25:25
+ERROR - Name 'all' is reserved

--- a/dim/dim/rpc.py
+++ b/dim/dim/rpc.py
@@ -301,6 +301,8 @@ class RPC(object):
     @updating
     def layer3domain_create(self, name, type, comment=None, **options):
         self.user.can_network_admin()
+        if name == "all":
+            raise InvalidParameterError("Name 'all' is reserved")
         if Layer3Domain.query.filter_by(name=name).count():
             raise AlreadyExistsError("A layer3domain named '%s' already exists" % name)
         if type not in Layer3Domain.TYPES:


### PR DESCRIPTION
Fixes #165

Do not allow layer3domain 'all' because it is used as a keyword in the
API to return all layer3domains.