### PR TITLE
fix ldap_sync and ldap_auth for ldap3

### DIFF
--- a/dim/dim/ldap_auth.py
+++ b/dim/dim/ldap_auth.py
@@ -20,7 +20,6 @@ def check_credentials(username: str, password: str):
     if app.config['LDAP_SEARCH_BASE']:
         user_dn += "," + app.config['LDAP_SEARCH_BASE']
 
-    server = ldap3.Server(app.config['LDAP_SERVER'])
     conn = ldap3.Connection(ldap_server, user=user_dn, password=password, client_strategy=ldap3.SAFE_SYNC)
     if not conn.bind():
         logging.info('LDAP login for user %s failed: %s', username, conn.result)

--- a/dim/dim/ldap_auth.py
+++ b/dim/dim/ldap_auth.py
@@ -1,16 +1,27 @@
 import logging
 
 import ldap3
+import ssl
 from flask import current_app as app
 
+def check_credentials(username: str, password: str):
+    server_kwargs = {}
+    tls_kwargs = app.config.get_namespace('LDAP_SERVER_TLS_')
+    if app.config['LDAP_SERVER'].startswith('ldaps'):
+        if 'validate' in tls_kwargs.keys() and tls_kwargs.get('validate'):
+            tls_kwargs['validate'] = ssl.CERT_NONE
+        else:
+            tls_kwargs['validate'] = ssl.CERT_REQUIRED
+        server_kwargs['tls'] = ldap3.Tls(**tls_kwargs)
 
-def check_credentials(username, password):
+    ldap_server = ldap3.Server(app.config['LDAP_SERVER'], **server_kwargs)
+
     user_dn = app.config['LDAP_USER_DN'] % username
     if app.config['LDAP_SEARCH_BASE']:
         user_dn += "," + app.config['LDAP_SEARCH_BASE']
 
     server = ldap3.Server(app.config['LDAP_SERVER'])
-    conn = ldap3.Connection(server, user=user_dn, password=password, client_strategy=SAFE_SYNC)
+    conn = ldap3.Connection(ldap_server, user=user_dn, password=password, client_strategy=ldap3.SAFE_SYNC)
     if not conn.bind():
         logging.info('LDAP login for user %s failed: %s', username, conn.result)
         return False

--- a/dim/dim/ldap_auth.py
+++ b/dim/dim/ldap_auth.py
@@ -21,7 +21,7 @@ def check_credentials(username: str, password: str):
         user_dn += "," + app.config['LDAP_SEARCH_BASE']
 
     conn = ldap3.Connection(ldap_server, user=user_dn, password=password, client_strategy=ldap3.SAFE_SYNC)
-    if not conn.bind():
-        logging.info('LDAP login for user %s failed: %s', username, conn.result)
-        return False
-    return True
+    (status, result, response, request) = conn.bind()
+    if not status:
+        logging.info('LDAP login for user %s failed: %s', username, result)
+    return status

--- a/dim/dim/ldap_sync.py
+++ b/dim/dim/ldap_sync.py
@@ -26,8 +26,13 @@ class LDAP(object):
 
         ldap_server = ldap3.Server(app.config['LDAP_SERVER'], **server_kwargs)
         conn = ldap3.Connection(ldap_server, read_only=True, client_strategy=ldap3.SAFE_SYNC)
-        if not conn.bind():
-            logging.exception('Error connecting to ldap server %s: %s', ldap_server, conn.result)
+        try:
+            (status, result, response, request) = conn.bind()
+        except ldap3.core.exceptions.LDAPExceptionError as e:
+            logging.exception('Error connecting to ldap server %s: %s', ldap_server, e)
+            raise
+        if not status:
+            logging.exception('Error connecting to ldap server %s: %s', ldap_server, result)
             raise
         self.conn = conn
 

--- a/dim/dim/ldap_sync.py
+++ b/dim/dim/ldap_sync.py
@@ -4,57 +4,65 @@ import logging
 import sys
 
 import ldap3
+import ssl
 from flask import current_app as app
 
 from dim import db
 from dim.models import Group, User, GroupMembership, Department
 from dim.transaction import time_function, transaction
+from typing import List
 
 
 class LDAP(object):
     def __init__(self):
-        ldap_server = ldap3.Server(app.config['LDAP_SERVER'])
-        conn = ldap3.Connection(ldap_server, read_only=True)
+        server_kwargs = {}
+        tls_kwargs = app.config.get_namespace('LDAP_SERVER_TLS_')
+        if app.config['LDAP_SERVER'].startswith('ldaps'):
+            if 'validate' in tls_kwargs.keys() and not tls_kwargs['validate']:
+                tls_kwargs['validate'] = ssl.CERT_NONE
+            else:
+                tls_kwargs['validate'] = ssl.CERT_REQUIRED
+            server_kwargs['tls'] = ldap3.Tls(**tls_kwargs)
+
+        ldap_server = ldap3.Server(app.config['LDAP_SERVER'], **server_kwargs)
+        conn = ldap3.Connection(ldap_server, read_only=True, client_strategy=ldap3.SAFE_SYNC)
         if not conn.bind():
             logging.exception('Error connecting to ldap server %s: %s', ldap_server, conn.result)
             raise
         self.conn = conn
 
-    def query(self, base, filter):
+    def query(self, base: str, search_filter: str, attributes: List[str] = None):
         try:
-            if filter:
-                return self.conn.search(base, filter, search_scope=ldap.LEVEL)
-            else:
-                return self.conn.search(base, '()', scope=ldap3.LEVEL)
+            status, result, response, _ = self.conn.search(base, search_filter, attributes=attributes, search_scope=ldap3.LEVEL)
+            return response
         except:
-            logging.exception('Error in LDAP query %s %s', base, filter)
+            logging.exception('Error in LDAP query %s %s', base, search_filter)
             raise
 
-    def users(self, filter):
+    def users(self, search_filter: str, attributes: List[str] = ['o', 'cn', 'uid', 'departmentNumber']):
         '''Return the set of usernames matching the ldap query.'''
         def fix_int(s): return int(s) if s is not None else s
-        return [User(username=u[1]['o'][0].decode('utf-8'),
-                     ldap_cn=u[1]['cn'][0].decode('utf-8'),
-                     ldap_uid=fix_int(u[1]['uid'][0]),
-                     department_number=fix_int(u[1]['departmentNumber'][0]),
+        return [User(username=u['attributes']['o'][0],
+                     ldap_cn=u['attributes']['cn'][0],
+                     ldap_uid=fix_int(u['attributes']['uid'][0]),
+                     department_number=fix_int(u['attributes']['departmentNumber'][0]),
                      register=False)
-                for u in self.query(app.config['LDAP_USER_BASE'], filter)]
+                for u in self.query(app.config['LDAP_USER_BASE'], search_filter, attributes)]
 
-    def departments(self, filter):
+    def departments(self, search_filter: str = '(objectClass=organizationalUnit)', attributes: List[str] = ['ou', 'cn']):
         '''Return the list of departments'''
-        res = self.query(app.config['LDAP_DEPARTMENT_BASE'], filter)
+        res = self.query(app.config['LDAP_DEPARTMENT_BASE'], search_filter, attributes)
         if not res:
             return []
         else:
-            return [Department(department_number=int(dept[1]['ou'][0]),
-                               name=dept[1]['cn'][0].decode('utf-8'))
+            return [Department(department_number=int(dept['attributes']['ou'][0]),
+                               name=dept['attributes']['cn'][0])
                     for dept in res]
 
-
-def sync_departments(ldap, dry_run=False):
+def sync_departments(ldap: LDAP, dry_run: bool = False):
     '''Update the department table'''
     db_departments = Department.query.all()
-    ldap_departments = dict((dep.department_number, dep) for dep in ldap.departments(None))
+    ldap_departments = dict((dep.department_number, dep) for dep in ldap.departments())
     # handle renamed or deleted departments
     for ddep in db_departments:
         ldep = ldap_departments.get(ddep.department_number)
@@ -75,12 +83,12 @@ def sync_departments(ldap, dry_run=False):
             db.session.add(ldep)
 
 
-def log_stdout(message):
+def log_stdout(message: str):
     logging.info(message)
     print(message)
 
 
-def sync_users(ldap, dry_run=False):
+def sync_users(ldap: LDAP, dry_run: bool = False):
     '''Update the user table ldap_cn, ldap_uid and department_number fields'''
     db_users = User.query.all()
     ldap_users = dict((u.username, u)
@@ -117,7 +125,7 @@ def sync_users(ldap, dry_run=False):
 
 @time_function
 @transaction
-def ldap_sync(dry_run=False):
+def ldap_sync(dry_run: bool = False):
     ldap = LDAP()
 
     if sys.stdout.isatty():


### PR DESCRIPTION
This makes LDAP Authentication and Sync work again with ldap3, see #166 / #167
* `()` is not a valid filter in ldap3, require a proper one for query()
* specify attributes we want from LDAP for easier access
* support setting TLS parameters for the LDAP connection from the config file
* add minimal typing

Allowing custom TLS parameters to support e.g. disabling verification in development
environments, or using a specific certificate file to verify against.