### PR TITLE
Pool owning group

### DIFF
--- a/dim-testsuite/t/group-pools.t
+++ b/dim-testsuite/t/group-pools.t
@@ -3,6 +3,13 @@ $ ndcli create pool p owning-user-group g
 $ ndcli list user-group g pools
 name
 p
+$ ndcli modify pool p remove owning-user-group
+$ ndcli list user-group g pools
+name
+$ ndcli modify pool p set owning-user-group g
+$ ndcli list user-group g pools
+name
+p
 $ ndcli delete user-group g
 $ ndcli delete pool p
 $ ndcli list user-group g pools

--- a/dim/dim/rpc.py
+++ b/dim/dim/rpc.py
@@ -1224,6 +1224,11 @@ class RPC(object):
         get_pool(poolname).owner = get_group(owner)
 
     @updating
+    def ippool_unset_owner(self, poolname):
+        self.user.can_modify_pool_attributes()
+        get_pool(poolname).owner = None
+
+    @updating
     def ippool_delete_attrs(self, name, attribute_names):
         self.user.can_modify_pool_attributes()
         get_pool(name).delete_attrs(attribute_names)

--- a/ndcli/dimcli/__init__.py
+++ b/ndcli/dimcli/__init__.py
@@ -1118,6 +1118,23 @@ class CLI(object):
         '''
         self.client.ippool_set_owner(args.poolname, args.group)
 
+    @cmd.register('modify pool set owning-user-group',
+            group_arg,
+            help='set owner group for POOLNAME')
+    def modify_pool_set_owning_user_group(self, args):
+        '''
+        Sets the pool owning user group.
+        '''
+        self.client.ippool_set_owner(args.poolname, args.group)
+
+    @cmd.register('modify pool remove owning-user-group',
+            help='unset owner group for POOLNAME')
+    def modify_pool_set_owning_user_group(self, args):
+        '''
+        Unsets the pool owning user group.
+        '''
+        self.client.ippool_unset_owner(args.poolname)
+
     @cmd.register('modify pool remove attrs',
                   attr_names_arg,
                   help='remove attributes from POOLNAME')
@@ -1572,7 +1589,7 @@ class CLI(object):
                 print('  ' * level + '%s %s' % (node['ip'], ' '.join(attributes)))
                 if 'children' in node:
                     print_tree(node['children'], level + 1)
-                    
+
         layer3domains = [args.layer3domain]
         if args.layer3domain == "all":
             layer3domains = [l['name'] for l in self.client.layer3domain_list()]


### PR DESCRIPTION
Fixes #138 

This adds a new command line option to set and unset the owning group on pools.

We should maybe deprecate the old command line flag. If we do, how should that be done? Only in documentation or also with a debug message?