### PR TITLE
ndcli - allow override of ndclirc

### DIFF
--- a/dim-testsuite/Makefile
+++ b/dim-testsuite/Makefile
@@ -7,6 +7,7 @@ LDIR          ?= log
 SRVLOG        ?= ${LDIR}/server.log
 NDCLI_USERNAME ?= admin
 NDCLI_SERVER   ?= http://localhost:5000
+NDCLI_CONFIG  ?= /dev/null
 
 all: install db test
 	mkdir ${VDIR}
@@ -34,6 +35,7 @@ test:
   	   TEST_OUTPUT_DIR="${ODIR}" \
 			 SRVLOG="${SRVLOG}" \
        NDCLI_USERNAME="${NDCLI_USERNAME}" \
+			 NDCLI_CONFIG="${NDCLI_CONFIG}" \
 			 NDCLI_SERVER="${NDCLI_SERVER}" ${VPYTHON} runtest.py -d
 
 .PHONY: db test install clean

--- a/ndcli/dimcli/__init__.py
+++ b/ndcli/dimcli/__init__.py
@@ -35,13 +35,20 @@ def _readconfig(config_file):
         logger.debug('Configuration file cannot be read: %s' % e)
     return config
 
-config = _readconfig(os.path.expanduser('~/.ndclirc'))
+config_path = os.getenv('NDCLI_CONFIG', '~/ndclirc')
+config = _readconfig(os.path.expanduser(config_path))
 
-# get_layer3domain returns from_args or the layer3domain from ndclirc.
+# get_layer3domain returns from_args, from the environment variable or the
+# layer3domain from ndclirc.
 def get_layer3domain(from_args):
-    if from_args is None:
+    if from_args is not None:
+        return from_args
+    env_l3 = os.getenv('NDCLI_LAYER3DOMAIN', None)
+    if env_l3 is not None:
+        return env_l3
+    if 'layer3domain' in config:
         return config['layer3domain']
-    return from_args
+    return None
 
 def dim_client(args):
     server_url = args.server or os.getenv('NDCLI_SERVER', config['server'])

--- a/ndcli/doc/man.rst
+++ b/ndcli/doc/man.rst
@@ -9,6 +9,7 @@ ndcli reads "key=value" pairs from ``~/.ndclirc``. An example::
 
     server   = https://localhost/dim
     username = admin
+    layer3domain = default
 
 The recognized keys are:
 
@@ -18,11 +19,41 @@ server
 username
     The Dim user name (used for authentication). Defaults to the name of the current user.
 
+layer3domain
+    The layer3domain must be set with every request when more than one layer3domain is used.
+    By setting it in the config it will be used as the default layer3domain.
+    The default layer3domain is ``default``.
+
+Environment Variables
+=====================
+
+It is possible to control ndcli with environment variables. With these the settings
+from the configuration file can be overwritten. The following settings are supported:
+
+NDCLI_CONFIG
+    Set the path to a specific ndclirc path (default: ``~/.ndclirc``)
+
+NDCLI_COOKIEPATH
+    This setting controls which cookie file should be used. When it does not
+    contain a session matching the server, a login will be required.
+    (default ``~/.ndcli.cookie.{username}``)
+
+NDCLI_LAYER3DOMAIN
+    Set the layer3domain to use as the new default value.
+
+NDCLI_SERVER
+    Set the dim server URL. When this is not set, the value from the config
+    will be used.
+
+NDCLI_USERNAME
+    Set the username that ndcli should use. By default the system username will
+    be used.
+
 Login
 =====
 
 ndcli stores the HTTP cookie received from the Dim server in
-``~/.ndcli.cookie``. A future run will use the cookie from this file if it's
+``~/.ndcli.cookie.<username>``. A future run will use the cookie from this file if it's
 still valid (to avoid asking for username/password). However, if you wish to
 force re-authentication, you can delete the file.
 


### PR DESCRIPTION
For debugging it is a hindrance to pull in the default `~/.ndclirc` as
it might contain overrides for some variables.

To avoid the problem a new environment variable NDCLI_CONFIG is defined
to point ndcli somewhere else for the config. This is also the default
for running the tests and can be overriden with the same environment
variable.

This would also allow users to have multiple configs for each
layer3domain they are using and prepare them as aliases, for example

```
alias ndcli_orgA=NDCLI_CONFIG=~/.ndclirc_orgA ndcli
alias ndcli_orgB=NDCLI_CONFIG=~/.ndclirc_orgB ndcli
```