### PR TITLE
add API to move container to layer3domain

### DIFF
--- a/dim-testsuite/t/container_move_layer3domain.t
+++ b/dim-testsuite/t/container_move_layer3domain.t
@@ -1,0 +1,146 @@
+$ ndcli create layer3domain a type test
+$ ndcli create layer3domain b type test
+$ ndcli create container 10.0.0.0/8 layer3domain a
+INFO - Creating container 10.0.0.0/8 in layer3domain a
+$ ndcli create container 10.0.0.0/8 layer3domain b
+INFO - Creating container 10.0.0.0/8 in layer3domain b
+$ ndcli create container 10.0.4.0/22 layer3domain a
+INFO - Creating container 10.0.4.0/22 in layer3domain a
+$ ndcli create container 10.0.6.0/24 layer3domain a
+INFO - Creating container 10.0.6.0/24 in layer3domain a
+$ ndcli create pool a layer3domain a
+$ ndcli create pool b layer3domain b
+$ ndcli modify pool a add subnet 10.0.5.0/24
+INFO - Created subnet 10.0.5.0/24 in layer3domain a
+WARNING - Creating zone 5.0.10.in-addr.arpa without profile
+WARNING - Primary NS for this Domain is now localhost.
+$ ndcli modify pool b add subnet 10.0.5.0/24 --allow-overlap
+INFO - Created subnet 10.0.5.0/24 in layer3domain b
+WARNING - 10.0.5.0/24 in layer3domain b overlaps with 10.0.5.0/24 in layer3domain a
+INFO - Creating view b in zone 5.0.10.in-addr.arpa without profile
+$ ndcli create rr test.t. A 10.0.4.1 layer3domain a
+INFO - Marked IP 10.0.4.1 from layer3domain a as static
+INFO - No zone found for test.t.
+INFO - No zone found for 1.4.0.10.in-addr.arpa.
+WARNING - No record was created because no forward or reverse zone found.
+$ ndcli create rr test.t. A 10.0.5.1 layer3domain a
+INFO - Marked IP 10.0.5.1 from layer3domain a as static
+INFO - No zone found for test.t.
+INFO - Creating RR 1 PTR test.t. in zone 5.0.10.in-addr.arpa view a
+WARNING - No forward zone found. Only creating reverse entry.
+$ ndcli list containers layer3domain all
+layer3domain: default
+
+layer3domain: a
+10.0.0.0/8 (Container)
+  10.0.0.0/22 (Available)
+  10.0.4.0/22 (Container)
+    10.0.4.1 (Static)
+    10.0.4.2/31 (Available)
+    10.0.4.4/30 (Available)
+    10.0.4.8/29 (Available)
+    10.0.4.16/28 (Available)
+    10.0.4.32/27 (Available)
+    10.0.4.64/26 (Available)
+    10.0.4.128/25 (Available)
+    10.0.5.0/24 (Subnet) pool:a
+    10.0.6.0/24 (Container)
+      10.0.6.0/24 (Available)
+    10.0.7.0/24 (Available)
+  10.0.8.0/21 (Available)
+  10.0.16.0/20 (Available)
+  10.0.32.0/19 (Available)
+  10.0.64.0/18 (Available)
+  10.0.128.0/17 (Available)
+  10.1.0.0/16 (Available)
+  10.2.0.0/15 (Available)
+  10.4.0.0/14 (Available)
+  10.8.0.0/13 (Available)
+  10.16.0.0/12 (Available)
+  10.32.0.0/11 (Available)
+  10.64.0.0/10 (Available)
+  10.128.0.0/9 (Available)
+
+layer3domain: b
+10.0.0.0/8 (Container)
+  10.0.0.0/22 (Available)
+  10.0.4.0/24 (Available)
+  10.0.5.0/24 (Subnet) pool:b
+  10.0.6.0/23 (Available)
+  10.0.8.0/21 (Available)
+  10.0.16.0/20 (Available)
+  10.0.32.0/19 (Available)
+  10.0.64.0/18 (Available)
+  10.0.128.0/17 (Available)
+  10.1.0.0/16 (Available)
+  10.2.0.0/15 (Available)
+  10.4.0.0/14 (Available)
+  10.8.0.0/13 (Available)
+  10.16.0.0/12 (Available)
+  10.32.0.0/11 (Available)
+  10.64.0.0/10 (Available)
+  10.128.0.0/9 (Available)
+$ ndcli modify container 10.0.4.0/22 layer3domain a move to b
+INFO - moving pool 10.0.6.0/24 from parent 10.0.4.0/22 to parent 10.0.0.0/8
+INFO - moving pool 10.0.5.0/24 from parent 10.0.4.0/22 to parent 10.0.0.0/8
+INFO - moving static ip 10.0.4.1 to layer3domain b
+$ ndcli list containers layer3domain all
+layer3domain: default
+
+layer3domain: a
+10.0.0.0/8 (Container)
+  10.0.0.0/22 (Available)
+  10.0.4.0/24 (Available)
+  10.0.5.0/24 (Subnet) pool:a
+  10.0.6.0/24 (Container)
+    10.0.6.0/24 (Available)
+  10.0.7.0/24 (Available)
+  10.0.8.0/21 (Available)
+  10.0.16.0/20 (Available)
+  10.0.32.0/19 (Available)
+  10.0.64.0/18 (Available)
+  10.0.128.0/17 (Available)
+  10.1.0.0/16 (Available)
+  10.2.0.0/15 (Available)
+  10.4.0.0/14 (Available)
+  10.8.0.0/13 (Available)
+  10.16.0.0/12 (Available)
+  10.32.0.0/11 (Available)
+  10.64.0.0/10 (Available)
+  10.128.0.0/9 (Available)
+
+layer3domain: b
+10.0.0.0/8 (Container)
+  10.0.0.0/22 (Available)
+  10.0.4.0/22 (Container)
+    10.0.4.1 (Static)
+    10.0.4.2/31 (Available)
+    10.0.4.4/30 (Available)
+    10.0.4.8/29 (Available)
+    10.0.4.16/28 (Available)
+    10.0.4.32/27 (Available)
+    10.0.4.64/26 (Available)
+    10.0.4.128/25 (Available)
+    10.0.5.0/24 (Subnet) pool:b
+    10.0.6.0/23 (Available)
+  10.0.8.0/21 (Available)
+  10.0.16.0/20 (Available)
+  10.0.32.0/19 (Available)
+  10.0.64.0/18 (Available)
+  10.0.128.0/17 (Available)
+  10.1.0.0/16 (Available)
+  10.2.0.0/15 (Available)
+  10.4.0.0/14 (Available)
+  10.8.0.0/13 (Available)
+  10.16.0.0/12 (Available)
+  10.32.0.0/11 (Available)
+  10.64.0.0/10 (Available)
+  10.128.0.0/9 (Available)
+$ ndcli history ipblock 10.0.4.0/22
+timestamp                  user  tool   originating_ip objclass name        action
+2022-01-18 12:24:18.681149 admin native 127.0.0.1      ipblock  10.0.4.0/22 set_attr layer3domain=b in layer3domain b
+2022-01-18 12:24:17.370030 admin native 127.0.0.1      ipblock  10.0.4.0/22 created in layer3domain a
+$ ndcli history ipblock 10.0.4.1
+timestamp                  user  tool   originating_ip objclass name     action
+2022-01-18 12:24:18.682816 admin native 127.0.0.1      ipblock  10.0.4.1 set_attr layer3domain=b in layer3domain b
+2022-01-18 12:24:18.210161 admin native 127.0.0.1      ipblock  10.0.4.1 created in layer3domain a

--- a/dim-testsuite/t/container_move_layer3domain.t
+++ b/dim-testsuite/t/container_move_layer3domain.t
@@ -28,6 +28,12 @@ INFO - Marked IP 10.0.5.1 from layer3domain a as static
 INFO - No zone found for test.t.
 INFO - Creating RR 1 PTR test.t. in zone 5.0.10.in-addr.arpa view a
 WARNING - No forward zone found. Only creating reverse entry.
+$ ndcli create container 10.0.4.0/22 layer3domain b
+INFO - Creating container 10.0.4.0/22 in layer3domain b
+$ ndcli modify container 10.0.4.0/22 layer3domain a move to b
+ERROR - container 10.0.4.0/22 already exists in layer3domain b
+$ ndcli delete container 10.0.4.0/22 layer3domain b
+INFO - Deleting container 10.0.4.0/22 from layer3domain b
 $ ndcli list containers layer3domain all
 layer3domain: default
 
@@ -138,8 +144,10 @@ layer3domain: b
   10.128.0.0/9 (Available)
 $ ndcli history ipblock 10.0.4.0/22
 timestamp                  user  tool   originating_ip objclass name        action
-2022-01-18 12:24:18.681149 admin native 127.0.0.1      ipblock  10.0.4.0/22 set_attr layer3domain=b in layer3domain b
-2022-01-18 12:24:17.370030 admin native 127.0.0.1      ipblock  10.0.4.0/22 created in layer3domain a
+2022-02-02 13:50:50.289111 admin native 127.0.0.1      ipblock  10.0.4.0/22 set_attr layer3domain=b in layer3domain b
+2022-02-02 13:50:50.033176 admin native 127.0.0.1      ipblock  10.0.4.0/22 deleted in layer3domain b
+2022-02-02 13:50:49.791900 admin native 127.0.0.1      ipblock  10.0.4.0/22 created in layer3domain b
+2022-02-02 13:50:48.725891 admin native 127.0.0.1      ipblock  10.0.4.0/22 created in layer3domain a
 $ ndcli history ipblock 10.0.4.1
 timestamp                  user  tool   originating_ip objclass name     action
 2022-01-18 12:24:18.682816 admin native 127.0.0.1      ipblock  10.0.4.1 set_attr layer3domain=b in layer3domain b

--- a/dim/dim/models/history.py
+++ b/dim/dim/models/history.py
@@ -251,7 +251,7 @@ generate_history_table(
      Column('vlan', Integer, info={'filler': default_filler('vlan')})] +
     generate_attr_change_columns(),
     [Ipblock.version, Ipblock.address, Ipblock.prefix, Ipblock.priority, Ipblock.gateway,
-     Ipblock.status, Ipblock.pool, Ipblock.vlan],
+     Ipblock.status, Ipblock.pool, Ipblock.vlan, Ipblock.layer3domain],
     suppress_events=[Ipblock.version, Ipblock.address, Ipblock.prefix],
     indexes=[Index('ix_address_prefix_version', 'address', 'prefix', 'version')])
 

--- a/dim/dim/rpc.py
+++ b/dim/dim/rpc.py
@@ -557,6 +557,12 @@ class RPC(object):
         if block.status.name != 'Container':
             raise DimError('block is not a container')
 
+        if db.session.query(Ipblock). \
+                filter(Ipblock.address == block.address). \
+                filter(Ipblock.layer3domain == to_layer3domain). \
+                count() > 0:
+            raise DimError('container %s already exists in layer3domain %s' % (block.ip, to_layer3domain.name))
+
         # fix all pools first
         pools = db.session.query(Ipblock). \
                 join(IpblockStatus).filter(IpblockStatus.name != 'Static'). \

--- a/dim/dim/rpc.py
+++ b/dim/dim/rpc.py
@@ -548,6 +548,39 @@ class RPC(object):
         return attrs
 
     @updating
+    def ipblock_move_to(self, block, layer3domain, to_layer3domain, **options):
+        layer3domain = _get_layer3domain_arg(layer3domain, options)
+        to_layer3domain = _get_layer3domain_arg(to_layer3domain, options)
+        block = check_block(get_block(block, layer3domain), layer3domain, options)
+        self._can_change_ip_attributes(block)
+
+        if block.status.name != 'Container':
+            raise DimError('block is not a container')
+
+        # fix all pools first
+        pools = db.session.query(Ipblock). \
+                join(IpblockStatus).filter(IpblockStatus.name != 'Static'). \
+                filter(Ipblock.parent == block). \
+                filter(Ipblock.ippool_id is not None).all()
+        if block.parent is None and len(pools) > 0:
+            raise DimError('block has no parent but pools that need reassignment')
+        for pool in pools:
+            Messages.info("moving pool %s from parent %s to parent %s" % (pool, pool.parent.ip, block.parent.ip))
+            pool.parent = block.parent
+
+        # move all static IPs in container to the new layer3domain
+        ips = db.session.query(Ipblock).filter(Ipblock.parent==block). \
+                join(IpblockStatus).filter(IpblockStatus.name == 'Static').all()
+        block.layer3domain = to_layer3domain
+        for ip in ips:
+            Messages.info("moving static ip %s to layer3domain %s" % (ip.ip, to_layer3domain.name))
+            ip.layer3domain = to_layer3domain
+
+        # update parent and child settings of surrounding new containers and pools
+        block._tree_update()
+        return dict(messages=Messages.get())
+
+    @updating
     def ipblock_set_attrs(self, block, attributes, layer3domain=None, **options):
         layer3domain = _get_layer3domain_arg(layer3domain, options)
         block = check_block(get_block(block, layer3domain), layer3domain, options)

--- a/ndcli/dimcli/__init__.py
+++ b/ndcli/dimcli/__init__.py
@@ -293,6 +293,7 @@ cmd = Command('ndcli',
                               layer3domain_group,
                               Command('remove'),
                               Command('set'),
+                              Command('move'),
                               defaults=dict(block_type='container')),
                       Command('pool',
                               Argument('poolname', completions=complete_allocate_poolname),
@@ -1313,6 +1314,14 @@ class CLI(object):
         result = self.client.ippool_add_subnet(args.poolname, args.subnet, **options)
         if result['created']:
             logger.info("Created subnet %s in layer3domain %s" % (args.subnet, result['layer3domain']))
+        _print_messages(result)
+
+    @cmd.register('modify container move to', Argument('to_layer3domain'))
+    def ipblock_move_to(self, args):
+        result = self.client.ipblock_move_to(
+			args.container,
+			get_layer3domain(args.get('layer3domain')),
+			args.get('to_layer3domain'))
         _print_messages(result)
 
     # modify [block_type] set/remove attrs

--- a/ndcli/dimcli/__init__.py
+++ b/ndcli/dimcli/__init__.py
@@ -1318,10 +1318,13 @@ class CLI(object):
 
     @cmd.register('modify container move to', Argument('to_layer3domain'))
     def ipblock_move_to(self, args):
+        options = OptionDict()
+        options.set_if(dryrun=args.dryrun)
         result = self.client.ipblock_move_to(
 			args.container,
 			get_layer3domain(args.get('layer3domain')),
-			args.get('to_layer3domain'))
+			args.get('to_layer3domain'),
+            **options)
         _print_messages(result)
 
     # modify [block_type] set/remove attrs


### PR DESCRIPTION
fixes #124

Add the API and ndcli command to move a container to a new layer3domain.
All static entries directly underneath the container will be moved to
too. All other entries (subnets, reserved IPs, ...) will be kept und
attached to the parent container.
When no parent container exists the action will be aborted as it would
break the assumption that a subnet has a parent.