### PR TITLE
allow setting permanent_session to disabled

### DIFF
--- a/dim/dim/jsonrpc.py
+++ b/dim/dim/jsonrpc.py
@@ -56,7 +56,9 @@ def _do_login(authenticated, username, tool):
             db.session.commit()
             logging.debug('Created user %s' % username)
         session.clear()
-        session.permanent = request.form.get('permanent_session', False)
+        # get permanent_session from request form and check whether the value represents an enabled state, as bool
+        # default to False
+        session.permanent = request.form.get('permanent_session', False, lambda x: isinstance(x, str) and x.lower() in ['true', '1'])
         session['username'] = username
         if tool:
             session['tool'] = tool.lower()

--- a/dimclient/dimclient/__init__.py
+++ b/dimclient/dimclient/__init__.py
@@ -12,6 +12,7 @@ import time
 import os
 import os.path
 from pprint import pformat
+from typing import Optional
 from . import version
 
 __version__ = version.VERSION
@@ -36,19 +37,20 @@ class ProtocolError(DimError):
 
 
 class DimClient(object):
-    def __init__(self, server_url, cookie_file=None, cookie_umask=None):
+    def __init__(self, server_url: str, cookie_file: Optional[str] = None, cookie_umask: Optional[int] = None, permanent_session: bool = True):
         self.server_url = server_url
+        self.permanet_session = permanent_session
         self.cookie_jar = LWPCookieJar()
         self.session = build_opener(HTTPCookieProcessor(self.cookie_jar))
         if cookie_file:
             self._use_cookie_file(cookie_file, cookie_umask)
 
-    def login(self, username, password, permanent_session=False):
+    def login(self, username: str, password: str) -> bool:
         try:
             self.session.open(self.server_url + '/login',
                               urlencode(dict(username=username,
                                              password=password,
-                                             permanent_session=permanent_session)).encode('utf8'))
+                                             permanent_session=self.permanent_session)).encode('utf8'))
             self.check_protocol_version()
             self._update_cookie_file()
             return True
@@ -57,7 +59,7 @@ class DimClient(object):
             return False
 
     @property
-    def logged_in(self):
+    def logged_in(self) -> bool:
         try:
             self.session.open(self.server_url + '/index.html')
             # update cookie file with refreshed cookie(s) from response
@@ -79,7 +81,7 @@ class DimClient(object):
                 os.umask(old_mask)
 
 
-    def _use_cookie_file(self, cookie_file, cookie_umask, save_cookie=True):
+    def _use_cookie_file(self, cookie_file: str, cookie_umask: Optional[int] = None, save_cookie: bool = True):
         self.cookie_jar.filename = cookie_file
         self.save_cookie = save_cookie
         self.cookie_umask = cookie_umask
@@ -88,7 +90,7 @@ class DimClient(object):
         except:
             pass
 
-    def login_prompt(self, username=None, password=None, permanent_session=False, ignore_cookie=False):
+    def login_prompt(self, username=None, password=None, ignore_cookie=False):
         if not ignore_cookie and self.logged_in:
             return True
         else:
@@ -96,7 +98,7 @@ class DimClient(object):
                 username = input('Username: ')
             if password is None:
                 password = getpass.getpass()
-            return self.login(username, password, permanent_session)
+            return self.login(username, password)
 
     def check_protocol_version(self):
         try:

--- a/ndcli/dimcli/__init__.py
+++ b/ndcli/dimcli/__init__.py
@@ -50,13 +50,14 @@ def get_layer3domain(from_args):
         return config['layer3domain']
     return None
 
+
 def dim_client(args):
     server_url = args.server or os.getenv('NDCLI_SERVER', config['server'])
     username = args.username or os.getenv('NDCLI_USERNAME', config['username'])
     cookie_path = os.path.expanduser(os.getenv('NDCLI_COOKIEPATH', f'~/.ndcli.cookie.{username}'))
     logger.debug("Dim server URL: %s" % server_url)
     logger.debug("Username: %s" % username)
-    client = DimClient(server_url, cookie_file=cookie_path, cookie_umask=0o077)
+    client = DimClient(server_url, cookie_file=cookie_path, cookie_umask=0o077, permanent_session=True)
     if not client.logged_in:
         if not client.login_prompt(username=username, password=args.password, ignore_cookie=True):
             raise Exception('Could not log in')


### PR DESCRIPTION
Support disabled values for `permanent_session` during login.
Previously it would always evaluate to True
if the parameter was in the request.
This causes users of `dimclient` and `ndcli` to always get a permanent session.

Add `permanent_session` parameter for `DimClient`, defaulting to True,
as that's what the user expects.