### PR TITLE
allow filtering for layer3domains for history ipblock

### DIFF
--- a/dim-testsuite/t/history-layer3domain.t
+++ b/dim-testsuite/t/history-layer3domain.t
@@ -9,3 +9,17 @@ timestamp                  user  tool   originating_ip objclass     name action
 2019-01-14 14:13:00.687664 admin native 127.0.0.1      layer3domain two  set_attr comment=c
 2019-01-14 14:13:00.678273 admin native 127.0.0.1      layer3domain two  created
 2019-01-14 14:13:00.676887 admin native 127.0.0.1      layer3domain two  set_attr rd=2:2
+
+$ ndcli create layer3domain a type a
+$ ndcli create layer3domain b type b
+$ ndcli create container 10.0.0.0/8 layer3domain a
+INFO - Creating container 10.0.0.0/8 in layer3domain a
+$ ndcli create container 10.0.0.0/8 layer3domain b
+INFO - Creating container 10.0.0.0/8 in layer3domain b
+$ ndcli history ipblock 10.0.0.0/8
+timestamp                  user  tool   originating_ip objclass name       action
+2022-02-03 12:53:08.686055 admin native 127.0.0.1      ipblock  10.0.0.0/8 created in layer3domain b
+2022-02-03 12:53:08.546129 admin native 127.0.0.1      ipblock  10.0.0.0/8 created in layer3domain a
+$ ndcli history ipblock 10.0.0.0/8 layer3domain a
+timestamp                  user  tool   originating_ip objclass name       action
+2022-02-03 12:53:08.546129 admin native 127.0.0.1      ipblock  10.0.0.0/8 created in layer3domain a

--- a/dim/dim/rpc.py
+++ b/dim/dim/rpc.py
@@ -2946,11 +2946,9 @@ class RPC(object):
         ip = parse_ip(ipblock)
         hs = HistorySelect()
         query = hs.add_select(Ipblock)
-        logging.info('ipblock: %s %s %s' % (ip.address, ip.prefix, ip.version))
         query = query.where(hs.c.address == ip.address) \
             .where(hs.c.prefix == ip.prefix) \
             .where(hs.c.version == ip.version)
-        logging.info("layer3domain: %s" % (layer3domain))
         if layer3domain is not None:
             layer3domain = _get_layer3domain_arg(layer3domain)
             query.where(hs.c.layer3domain == layer3domain.name)

--- a/dim/dim/rpc.py
+++ b/dim/dim/rpc.py
@@ -2942,12 +2942,18 @@ class RPC(object):
         return hs.execute(limit, begin, end, incl=['layer3domain'])
 
     @readonly
-    def history_ipblock(self, ipblock, limit=None, begin=None, end=None):
+    def history_ipblock(self, ipblock, layer3domain, limit=None, begin=None, end=None):
         ip = parse_ip(ipblock)
         hs = HistorySelect()
-        hs.add_select(Ipblock).where(hs.c.address == ip.address) \
+        query = hs.add_select(Ipblock)
+        logging.info('ipblock: %s %s %s' % (ip.address, ip.prefix, ip.version))
+        query = query.where(hs.c.address == ip.address) \
             .where(hs.c.prefix == ip.prefix) \
             .where(hs.c.version == ip.version)
+        logging.info("layer3domain: %s" % (layer3domain))
+        if layer3domain is not None:
+            layer3domain = _get_layer3domain_arg(layer3domain)
+            query.where(hs.c.layer3domain == layer3domain.name)
         return hs.execute(limit, begin, end, incl=['layer3domain'])
 
     @readonly

--- a/ndcli/dimcli/__init__.py
+++ b/ndcli/dimcli/__init__.py
@@ -2922,8 +2922,8 @@ register_history('user-groups', arg_meta='groups', cmd_args=(),
                  f='history_group', fargs=lambda args: [None])
 register_history('pool', arg_meta='POOL', cmd_args=(Argument('poolname', completions=complete_allocate_poolname), ),
                  f='history_ippool', fargs=lambda args: [args.poolname])
-register_history('ipblock', arg_meta='IPBLOCK', cmd_args=(Argument('ipblock'), ),
-                 f='history_ipblock', fargs=lambda args: [args.ipblock])
+register_history('ipblock', arg_meta='IPBLOCK', cmd_args=(Argument('ipblock'), layer3domain_group),
+                 f='history_ipblock', fargs=lambda args: [args.ipblock, args.layer3domain])
 register_history('registrar-account', arg_meta='REGISTRAR_ACCOUNT', cmd_args=(registrar_account_arg, ),
                  f='history_registrar_account', fargs=lambda args: [args.registrar_account])
 register_history('layer3domain', arg_meta='LAYER3DOMAIN', cmd_args=(layer3domain_arg, ),


### PR DESCRIPTION
This adds the layer3domain option to `history ipblock` to limit the
history to a specific layer3domain.

Before it could happen that the history of the same IP or Prefix from
different layer3domains was shown.