### PR TITLE
fix logging and make db for the testsuite

### DIFF
--- a/dim-testsuite/Makefile
+++ b/dim-testsuite/Makefile
@@ -23,8 +23,8 @@ install:
 	${VPIP} install ../ndcli
 
 db:
-	mysql -h127.0.0.1 -P3307 -uroot pdns1 < ./testenv/pdns.sql
-	mysql -h127.0.0.1 -P3307 -uroot pdns2 < ./testenv/pdns.sql
+	mysql -h127.0.0.1 -P3307 -updns -ppdns pdns1 < ./testenv/pdns.sql
+	mysql -h127.0.0.1 -P3307 -updns -ppdns pdns2 < ./testenv/pdns.sql
 	${VDIR}/bin/manage_db clear
 
 test:
@@ -33,10 +33,11 @@ test:
 	${VDIR}/bin/manage_db clear
 
 	PATH="${VDIR}/bin:${PATH}" \
-  	   TEST_OUTPUT_DIR="${ODIR}" \
-			 SRVLOG="${SRVLOG}" \
-       NDCLI_USERNAME="${NDCLI_USERNAME}" \
-			 NDCLI_CONFIG="${NDCLI_CONFIG}" \
-			 NDCLI_SERVER="${NDCLI_SERVER}" ${VPYTHON} runtest.py -d
+	TEST_OUTPUT_DIR="${ODIR}" \
+	SRVLOG="${SRVLOG}" \
+	NDCLI_USERNAME="${NDCLI_USERNAME}" \
+	NDCLI_CONFIG="${NDCLI_CONFIG}" \
+	NDCLI_SERVER="${NDCLI_SERVER}" \
+	${VPYTHON} runtest.py -d
 
 .PHONY: db test install clean

--- a/dim-testsuite/Makefile
+++ b/dim-testsuite/Makefile
@@ -1,13 +1,13 @@
-PYTHON        ?= python3
-VDIR          ?= virtual_env
-ODIR          ?= out
-VPIP          ?= ${VDIR}/bin/pip3
-VPYTHON       ?= ${VDIR}/bin/python3
-LDIR          ?= log
-SRVLOG        ?= ${LDIR}/server.log
+PYTHON         ?= python3
+VDIR           ?= virtual_env
+ODIR           ?= out
+VPIP           ?= ${VDIR}/bin/pip3
+VPYTHON        ?= ${VDIR}/bin/python3
+LDIR           ?= log
+SRVLOG         ?= ${LDIR}/server.log
 NDCLI_USERNAME ?= admin
 NDCLI_SERVER   ?= http://localhost:5000
-NDCLI_CONFIG  ?= /dev/null
+NDCLI_CONFIG   ?= /dev/null
 
 all: install db test
 	mkdir ${VDIR}

--- a/dim-testsuite/Makefile
+++ b/dim-testsuite/Makefile
@@ -33,11 +33,11 @@ test:
 	${VDIR}/bin/manage_db clear
 
 	PATH="${VDIR}/bin:${PATH}" \
-	TEST_OUTPUT_DIR="${ODIR}" \
-	SRVLOG="${SRVLOG}" \
-	NDCLI_USERNAME="${NDCLI_USERNAME}" \
-	NDCLI_CONFIG="${NDCLI_CONFIG}" \
-	NDCLI_SERVER="${NDCLI_SERVER}" \
-	${VPYTHON} runtest.py -d
+		TEST_OUTPUT_DIR="${ODIR}" \
+		SRVLOG="${SRVLOG}" \
+		NDCLI_USERNAME="${NDCLI_USERNAME}" \
+		NDCLI_CONFIG="${NDCLI_CONFIG}" \
+		NDCLI_SERVER="${NDCLI_SERVER}" \
+		${VPYTHON} runtest.py -d
 
 .PHONY: db test install clean

--- a/dim-testsuite/Makefile
+++ b/dim-testsuite/Makefile
@@ -29,6 +29,7 @@ db:
 
 test:
 	-mkdir ${ODIR}
+	-mkdir ${LDIR}
 	${VDIR}/bin/manage_db clear
 
 	PATH="${VDIR}/bin:${PATH}" \

--- a/dim-testsuite/runtest.py
+++ b/dim-testsuite/runtest.py
@@ -21,7 +21,7 @@ import os.path
 import re
 import shlex
 import sys
-import urllib
+from urllib.parse import urlparse
 from io import StringIO
 from itertools import zip_longest
 from subprocess import Popen, PIPE, DEVNULL, STDOUT
@@ -383,12 +383,12 @@ def run_test(testfile, outfile, stop_on_error=False, auto_pdns_check=False):
 
 if __name__ == '__main__':
     # start the server process
-
-    parsed =urllib.parse.urlparse(os.getenv('NDCLI_SERVER', 'http://localhost:5000'))
+    parsed = urlparse(os.getenv('NDCLI_SERVER', 'http://localhost:5000'))
     host = parsed.hostname
     port = parsed.port
 
-    server = Popen(['manage_dim', 'runserver', '--port', str(port), '--host', host], stderr=SRVLOG, stdout=SRVLOG)
+    logfile = open(SRVLOG, 'wb+')
+    server = Popen(['manage_dim', 'runserver', '--port', str(port), '--host', str(host)], stderr=STDOUT, stdout=logfile)
 
     stop_on_error = False
     auto_pdns_check = False


### PR DESCRIPTION
Adjust the testsuite's `Makefile` to use the `pdns` user and credentials from the documentation instead of `root`.
Also create the log directory within `make test`, to make sure it's there, even when `make install`, `make db` and `make test` are run separately.

Set `stdout` to a file handle of the logfile instead of passing the path as string, as that's what `Popen()` requires.
Set `stderr` to `subprocess.STDOUT` to make it use the same file (handle).