### PR TITLE
Pool set layer3domain

### DIFF
--- a/dim-testsuite/t/pool_change_layer3domain.t
+++ b/dim-testsuite/t/pool_change_layer3domain.t
@@ -1,7 +1,10 @@
 # initialize layer3domains basic setup
-$ ndcli create zone-group test
-$ ndcli create output test plugin bind
-$ ndcli modify output test add zone-group test
+$ ndcli create zone-group a
+$ ndcli create zone-group b
+$ ndcli create output a plugin bind
+$ ndcli create output b plugin bind
+$ ndcli modify output a add zone-group a
+$ ndcli modify output b add zone-group b
 $ ndcli create zone t
 WARNING - Creating zone t without profile
 WARNING - Primary NS for this Domain is now localhost.
@@ -20,7 +23,8 @@ $ ndcli modify pool a add subnet 10.23.0.0/28
 INFO - Created subnet 10.23.0.0/28 in layer3domain a
 WARNING - Creating zone 0.23.10.in-addr.arpa without profile
 WARNING - Primary NS for this Domain is now localhost.
-# TODO replace with PTR
+$ ndcli modify zone-group a add zone 5.0.10.in-addr.arpa view a
+$ ndcli modify zone-group a add zone 0.23.10.in-addr.arpa view a
 $ ndcli create rr a.t. A 10.0.5.5 layer3domain a
 INFO - Marked IP 10.0.5.5 from layer3domain a as static
 INFO - Creating RR a A 10.0.5.5 in zone t
@@ -36,7 +40,6 @@ pool:a
 reverse_zone:5.0.10.in-addr.arpa
 status:Delegation
 subnet:10.0.5.0/24
-# TODO replace with PTR
 $ ndcli create rr b.t. A 10.0.5.66 layer3domain a
 INFO - Marked IP 10.0.5.66 from layer3domain a as static
 INFO - Creating RR b A 10.0.5.66 in zone t
@@ -173,3 +176,9 @@ timestamp                  user  tool   originating_ip objclass name        acti
 2022-02-01 09:25:46.324948 admin native 127.0.0.1      ipblock  10.0.5.0/24 created in layer3domain b
 2022-02-01 09:25:45.611436 admin native 127.0.0.1      ipblock  10.0.5.0/24 set_attr pool=a in layer3domain a
 2022-02-01 09:25:45.596906 admin native 127.0.0.1      ipblock  10.0.5.0/24 created in layer3domain a
+$ ndcli modify zone-group b add zone 5.0.10.in-addr.arpa view b
+$ ndcli modify zone-group b add zone 0.23.10.in-addr.arpa view b
+$ ndcli list outputs -t
+name plugin pending_records last_run status
+a    bind                 8
+b    bind                 4

--- a/dim-testsuite/t/pool_change_layer3domain.t
+++ b/dim-testsuite/t/pool_change_layer3domain.t
@@ -1,0 +1,175 @@
+# initialize layer3domains basic setup
+$ ndcli create zone-group test
+$ ndcli create output test plugin bind
+$ ndcli modify output test add zone-group test
+$ ndcli create zone t
+WARNING - Creating zone t without profile
+WARNING - Primary NS for this Domain is now localhost.
+$ ndcli create layer3domain a type a
+$ ndcli create layer3domain b type b
+$ ndcli create container 10.0.0.0/8 layer3domain a
+INFO - Creating container 10.0.0.0/8 in layer3domain a
+$ ndcli create container 10.0.0.0/8 layer3domain b
+INFO - Creating container 10.0.0.0/8 in layer3domain b
+$ ndcli create pool a layer3domain a
+$ ndcli modify pool a add subnet 10.0.5.0/24
+INFO - Created subnet 10.0.5.0/24 in layer3domain a
+WARNING - Creating zone 5.0.10.in-addr.arpa without profile
+WARNING - Primary NS for this Domain is now localhost.
+$ ndcli modify pool a add subnet 10.23.0.0/28
+INFO - Created subnet 10.23.0.0/28 in layer3domain a
+WARNING - Creating zone 0.23.10.in-addr.arpa without profile
+WARNING - Primary NS for this Domain is now localhost.
+# TODO replace with PTR
+$ ndcli create rr a.t. A 10.0.5.5 layer3domain a
+INFO - Marked IP 10.0.5.5 from layer3domain a as static
+INFO - Creating RR a A 10.0.5.5 in zone t
+INFO - Creating RR 5 PTR a.t. in zone 5.0.10.in-addr.arpa
+$ ndcli modify pool a mark delegation 10.0.5.64/30
+created:2022-01-21 13:12:21.858537
+ip:10.0.5.64/30
+layer3domain:a
+mask:255.255.255.0
+modified:2022-01-21 13:12:21.858562
+modified_by:admin
+pool:a
+reverse_zone:5.0.10.in-addr.arpa
+status:Delegation
+subnet:10.0.5.0/24
+# TODO replace with PTR
+$ ndcli create rr b.t. A 10.0.5.66 layer3domain a
+INFO - Marked IP 10.0.5.66 from layer3domain a as static
+INFO - Creating RR b A 10.0.5.66 in zone t
+INFO - Creating RR 66 PTR b.t. in zone 5.0.10.in-addr.arpa
+# create a collision target in layer3domain b
+$ ndcli create container 10.0.5.0/24 layer3domain b
+INFO - Creating container 10.0.5.0/24 in layer3domain b
+$ ndcli modify pool a set layer3domain b
+ERROR - subnet 10.0.5.0/24 can't be moved, 1 existing containers, subnets or static entries are in the way
+
+# remove overlapping container and create partial overlap
+$ ndcli delete container 10.0.5.0/24 layer3domain b
+INFO - Deleting container 10.0.5.0/24 from layer3domain b
+$ ndcli create pool fail layer3domain b
+$ ndcli modify pool fail add subnet 10.0.4.0/22 --allow-overlap
+INFO - Created subnet 10.0.4.0/22 in layer3domain b
+WARNING - 10.0.4.0/22 in layer3domain b overlaps with 10.0.5.0/24 in layer3domain a
+WARNING - Creating zone 4.0.10.in-addr.arpa without profile
+WARNING - Primary NS for this Domain is now localhost.
+INFO - Creating view b in zone 5.0.10.in-addr.arpa without profile
+WARNING - Creating zone 6.0.10.in-addr.arpa without profile
+WARNING - Primary NS for this Domain is now localhost.
+WARNING - Creating zone 7.0.10.in-addr.arpa without profile
+WARNING - Primary NS for this Domain is now localhost.
+$ ndcli modify pool a set layer3domain b
+ERROR - subnet 10.0.5.0/24 can't be moved, 3 existing containers, subnets or static entries are in the way
+
+## cleanup everything and make final move happen
+$ ndcli modify pool fail remove subnet 10.0.4.0/22
+INFO - Deleting zone 4.0.10.in-addr.arpa
+INFO - Deleting view b from zone 5.0.10.in-addr.arpa
+INFO - Deleting zone 6.0.10.in-addr.arpa
+INFO - Deleting zone 7.0.10.in-addr.arpa
+$ ndcli delete pool fail
+
+# check state before final move
+$ ndcli list pool a delegations
+INFO - Total free IPs: 3
+delegation   free total
+10.0.5.64/30    3     4
+$ ndcli list zone 5.0.10.in-addr.arpa views
+name
+a
+$ ndcli show ip 10.0.5.66 layer3domain a
+created:2022-02-01 09:14:46
+delegation:10.0.5.64/30
+ip:10.0.5.66
+layer3domain:a
+mask:255.255.255.0
+modified:2022-02-01 09:14:46
+modified_by:admin
+pool:a
+ptr_target:b.t.
+reverse_zone:5.0.10.in-addr.arpa
+status:Static
+subnet:10.0.5.0/24
+
+$ ndcli modify pool a set layer3domain b
+INFO - Changing subnet 10.0.5.0/24 to new parent 10.0.0.0/8 in layer3domain b
+INFO - Creating view b in zone 5.0.10.in-addr.arpa without profile
+INFO - Changing child 10.0.5.0 of subnet 10.0.5.0/24 to layer3domain b
+INFO - Changing child 10.0.5.5 of subnet 10.0.5.0/24 to layer3domain b
+INFO - Deleting RR 5 PTR a.t. from zone 5.0.10.in-addr.arpa view a
+INFO - Creating RR 5 PTR a.t. comment None in zone 5.0.10.in-addr.arpa view b
+INFO - Changing child 10.0.5.64/30 of subnet 10.0.5.0/24 to layer3domain b
+INFO - Changing child 10.0.5.255 of subnet 10.0.5.0/24 to layer3domain b
+INFO - Changing child 10.0.5.66 of subnet 10.0.5.0/24 to layer3domain b
+INFO - Deleting RR 66 PTR b.t. from zone 5.0.10.in-addr.arpa view a
+INFO - Creating RR 66 PTR b.t. comment None in zone 5.0.10.in-addr.arpa view b
+INFO - Deleting view a from zone 5.0.10.in-addr.arpa
+INFO - Changing subnet 10.23.0.0/28 to new parent 10.0.0.0/8 in layer3domain b
+INFO - Creating view b in zone 0.23.10.in-addr.arpa without profile
+INFO - Changing child 10.23.0.0 of subnet 10.23.0.0/28 to layer3domain b
+INFO - Changing child 10.23.0.15 of subnet 10.23.0.0/28 to layer3domain b
+INFO - Deleting view a from zone 0.23.10.in-addr.arpa
+
+# check state after the move
+$ ndcli list pool a delegations
+INFO - Total free IPs: 3
+delegation   free total
+10.0.5.64/30    3     4
+$ ndcli list zone 5.0.10.in-addr.arpa views
+name
+b
+$ ndcli show ip 10.0.5.66 layer3domain a
+ip:10.0.5.66
+status:Available
+$ ndcli show ip 10.0.5.66 layer3domain b
+created:2022-02-01 09:14:46
+delegation:10.0.5.64/30
+ip:10.0.5.66
+layer3domain:b
+mask:255.255.255.0
+modified:2022-02-01 09:14:46
+modified_by:admin
+pool:a
+ptr_target:b.t.
+reverse_zone:5.0.10.in-addr.arpa
+status:Static
+subnet:10.0.5.0/24
+$ ndcli history pool a
+timestamp                  user  tool   originating_ip objclass name action
+2022-02-01 09:17:52.468475 admin native 127.0.0.1      ippool   a    set_attr layer3domain=b
+2022-02-01 09:17:50.944328 admin native 127.0.0.1      ippool   a    create static 10.0.5.66
+2022-02-01 09:17:50.823374 admin native 127.0.0.1      ippool   a    create delegation 10.0.5.64/30
+2022-02-01 09:17:50.642992 admin native 127.0.0.1      ippool   a    create static 10.0.5.5
+2022-02-01 09:17:50.529698 admin native 127.0.0.1      ippool   a    create subnet 10.23.0.0/28
+2022-02-01 09:17:50.387248 admin native 127.0.0.1      ippool   a    create subnet 10.0.5.0/24
+2022-02-01 09:17:50.356266 admin native 127.0.0.1      ippool   a    set_attr version=4
+2022-02-01 09:17:50.234505 admin native 127.0.0.1      ippool   a    created in layer3domain a
+$ ndcli history ipblock 10.0.5.66
+timestamp                  user  tool   originating_ip objclass name      action
+2022-02-01 09:17:52.530755 admin native 127.0.0.1      ipblock  10.0.5.66 set_attr layer3domain=b in layer3domain b
+2022-02-01 09:17:50.939473 admin native 127.0.0.1      ipblock  10.0.5.66 created in layer3domain a
+$ ndcli history ipblock 10.0.5.5
+timestamp                  user  tool   originating_ip objclass name     action
+2022-02-01 09:17:52.503848 admin native 127.0.0.1      ipblock  10.0.5.5 set_attr layer3domain=b in layer3domain b
+2022-02-01 09:17:50.638336 admin native 127.0.0.1      ipblock  10.0.5.5 created in layer3domain a
+$ ndcli history ipblock 10.0.5.64/30
+timestamp                  user  tool   originating_ip objclass name         action
+2022-02-01 09:17:52.529946 admin native 127.0.0.1      ipblock  10.0.5.64/30 set_attr layer3domain=b in layer3domain b
+2022-02-01 09:17:50.817764 admin native 127.0.0.1      ipblock  10.0.5.64/30 created in layer3domain a
+$ ndcli list zone 5.0.10.in-addr.arpa
+record zone                ttl   type value
+     @ 5.0.10.in-addr.arpa 86400 SOA  localhost. hostmaster.5.0.10.in-addr.arpa. 2022020103 14400 3600 605000 86400
+     5 5.0.10.in-addr.arpa       PTR  a.t.
+    66 5.0.10.in-addr.arpa       PTR  b.t.
+$ ndcli history ipblock 10.0.5.0/24
+timestamp                  user  tool   originating_ip objclass name        action
+2022-02-01 09:25:47.801393 admin native 127.0.0.1      ipblock  10.0.5.0/24 set_attr layer3domain=b in layer3domain b
+2022-02-01 09:25:47.787609 admin native 127.0.0.1      ipblock  10.0.5.0/24 set_attr layer3domain=a in layer3domain a
+2022-02-01 09:25:47.729919 admin native 127.0.0.1      ipblock  10.0.5.0/24 set_attr layer3domain=b in layer3domain b
+2022-02-01 09:25:46.550123 admin native 127.0.0.1      ipblock  10.0.5.0/24 deleted in layer3domain b
+2022-02-01 09:25:46.324948 admin native 127.0.0.1      ipblock  10.0.5.0/24 created in layer3domain b
+2022-02-01 09:25:45.611436 admin native 127.0.0.1      ipblock  10.0.5.0/24 set_attr pool=a in layer3domain a
+2022-02-01 09:25:45.596906 admin native 127.0.0.1      ipblock  10.0.5.0/24 created in layer3domain a

--- a/dim/dim/models/history.py
+++ b/dim/dim/models/history.py
@@ -240,7 +240,7 @@ generate_history_table(
      Column('address', Numeric(precision=40, scale=0)),
      Column('prefix', Integer)] +
     generate_attr_change_columns(),
-    [Pool.name, Pool.version, Pool.description, Pool.vlan],
+    [Pool.name, Pool.version, Pool.description, Pool.vlan, Pool.layer3domain],
     indexes=[Index('ix_name', 'name')])
 
 generate_history_table(
@@ -251,7 +251,7 @@ generate_history_table(
      Column('vlan', Integer, info={'filler': default_filler('vlan')})] +
     generate_attr_change_columns(),
     [Ipblock.version, Ipblock.address, Ipblock.prefix, Ipblock.priority, Ipblock.gateway,
-     Ipblock.status, Ipblock.pool, Ipblock.vlan],
+     Ipblock.status, Ipblock.pool, Ipblock.vlan, Ipblock.layer3domain],
     suppress_events=[Ipblock.version, Ipblock.address, Ipblock.prefix],
     indexes=[Index('ix_address_prefix_version', 'address', 'prefix', 'version')])
 

--- a/dim/dim/rpc.py
+++ b/dim/dim/rpc.py
@@ -1213,6 +1213,7 @@ class RPC(object):
         pool = get_pool(pool)
         from_layer3domain = pool.layer3domain
         layer3domain = get_layer3domain(layer3domain)
+        logging.info("moving pool %s from layer3domain %s to layer3domain %s" % (pool.name, from_layer3domain.name, layer3domain.name))
 
         pool.layer3domain = layer3domain
         # check overlaps in target layer3domain and check for new parent
@@ -1291,6 +1292,7 @@ class RPC(object):
             self._delete_reverse_zones(subnet, force=False)
             subnet.layer3domain = layer3domain
 
+        logging.info("finished moving pool %s from layer3domain %s to layer3domain %s" % (pool.name, from_layer3domain.name, layer3domain.name))
         return {'messages': Messages.get()}
 
     @readonly

--- a/dim/dim/rpc.py
+++ b/dim/dim/rpc.py
@@ -13,6 +13,7 @@ from flask import current_app as app, g
 from sqlalchemy import between, and_, or_, not_, select, String, desc
 from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.orm import aliased, joinedload, contains_eager
+from sqlalchemy.orm.session import make_transient
 from sqlalchemy.sql.expression import literal, func, FunctionElement, distinct
 
 import dim.dns
@@ -1205,6 +1206,92 @@ class RPC(object):
                 subnet.vlan = None
                 subnet.update_modified()
         pool.vlan = None
+
+    @updating
+    def ippool_set_layer3domain(self, pool, layer3domain):
+        self.user.can_network_admin()
+        pool = get_pool(pool)
+        from_layer3domain = pool.layer3domain
+        layer3domain = get_layer3domain(layer3domain)
+
+        pool.layer3domain = layer3domain
+        # check overlaps in target layer3domain and check for new parent
+        for subnet in pool.subnets:
+            parent = db.session.query(Ipblock) \
+                    .filter(Ipblock.layer3domain == layer3domain) \
+                    .filter(Ipblock.address <= subnet.address) \
+                    .filter(Ipblock.prefix < subnet.prefix) \
+                    .join(IpblockStatus).filter(IpblockStatus.name == 'Container') \
+                    .order_by(Ipblock.address.desc(), Ipblock.prefix) \
+                    .limit(1)
+            if parent.first() is None:
+                raise DimError('could not find new parent for subnet "%s" in new layer3domain' % (subnet.ip))
+
+            overlaps = db.session.query(Ipblock) \
+                    .filter(Ipblock.layer3domain == layer3domain) \
+                    .filter(Ipblock.address.between(subnet.address - 1, subnet.ip.broadcast.address)) \
+                    .filter(Ipblock.prefix >= subnet.prefix) \
+                    .count()
+            if overlaps > 0:
+                raise DimError('''subnet %s can't be moved, %d existing containers, subnets or static entries are in the way''' % (subnet.ip, overlaps))
+
+            overlaps = db.session.query(Ipblock) \
+                    .filter(Ipblock.layer3domain == layer3domain) \
+                    .filter(Ipblock.address <= subnet.address) \
+                    .filter(Ipblock.prefix < subnet.prefix) \
+                    .join(IpblockStatus).filter(IpblockStatus.name != 'Container') \
+                    .order_by(Ipblock.address.desc(), Ipblock.prefix) \
+                    .limit(1)
+            if (overlaps is not None and overlaps.first() is not None
+                    and subnet.parent is not None):
+                    overlap = overlaps.first()
+                    if (overlap.address >= subnet.address and overlap.address <= subnet.ip.broadcast.address) or \
+                       (overlap.ip.broadcast.address >= subnet.address and overlap.ip.broadcast.address <= subnet.ip.broadcast.address):
+                        raise DimError('''subnet %s can't be moved, %s already exists and is a %s''' % (subnet.ip, overlaps.first().ip, overlaps.first().status.name))
+
+            subnet.layer3domain = layer3domain
+            subnet.parent = parent.first()
+            Messages.info("Changing subnet %s to new parent %s in layer3domain %s" % (subnet.ip, parent.first().ip, layer3domain.name))
+
+            self._create_reverse_zones(subnet)
+            children = subnet.children.all()
+            for child in children:
+                logging.info("Changing child %s of subnet %s to layer3domain %s" % (child.ip, subnet.ip, layer3domain.name))
+                Messages.info("Changing child %s of subnet %s to layer3domain %s" % (child.ip, subnet.ip, layer3domain.name))
+                if child.status.name == 'Static':
+                    child.layer3domain = layer3domain
+                    rr_name = dim.dns.get_ptr_name(child.ip)
+                    rr_zone = dim.dns.get_rr_zone(rr_name, None, None)
+                    new_view = db.session.query(ZoneView).filter(ZoneView.zone == rr_zone).filter(ZoneView.name == layer3domain.name).first()
+                    if new_view is None:
+                        raise DimError('view for layer3domain %s does not exist for zone %s' % (layer3domain.name, rr_zone.name))
+
+                    rr = db.session.query(RR).filter(RR.ipblock_id == child.id, RR.type == 'PTR').first()
+                    if rr is not None:
+                        rr.delete(send_delete_rr_event = True)
+                        Messages.info("Deleting RR %s from %s" % (rr.bind_str(relative=True), rr.view))
+                        make_transient(rr)
+                        rr.id = None
+                        rr.view = new_view
+                        rr.insert()
+                        Messages.info("Creating RR {rr}{comment_msg} in {view_msg}".format(
+                            rr=rr.bind_str(relative=True),
+                            comment_msg=' comment {0}'.format(rr.comment),
+                            view_msg=rr.view))
+
+                elif child.status.name == 'Delegation':
+                    children += child.children.all()
+                    child.layer3domain = layer3domain
+                elif child.status.name == 'Reserved':
+                    child.layer3domain = layer3domain
+                else:
+                    raise DimError("unhandled state '%s' for IP %s" % (child.status.name, child.ip))
+            # switch back layer3domain to delete old reverse zone
+            subnet.layer3domain = from_layer3domain
+            self._delete_reverse_zones(subnet, force=False)
+            subnet.layer3domain = layer3domain
+
+        return {'messages': Messages.get()}
 
     @readonly
     def ippool_get_attrs(self, pool):

--- a/ndcli/dimcli/__init__.py
+++ b/ndcli/dimcli/__init__.py
@@ -1151,7 +1151,9 @@ class CLI(object):
         '''
         Changes the layer3domain of a pool and all its dependencies.
         '''
-        result = self.client.ippool_set_layer3domain(args.poolname, args.layer3domain)
+        options = OptionDict()
+        options.set_if(dryrun=args.dryrun)
+        result = self.client.ippool_set_layer3domain(args.poolname, args.layer3domain, **options)
         if result:
             _print_messages(result)
 

--- a/ndcli/dimcli/__init__.py
+++ b/ndcli/dimcli/__init__.py
@@ -1144,6 +1144,17 @@ class CLI(object):
         '''
         self.client.ippool_set_owner(args.poolname, args.group)
 
+    @cmd.register('modify pool set layer3domain',
+            layer3domain_arg,
+            help='set new layer3domain for POOLNAME')
+    def modify_pool_set_layer3domain(self, args):
+        '''
+        Changes the layer3domain of a pool and all its dependencies.
+        '''
+        result = self.client.ippool_set_layer3domain(args.poolname, args.layer3domain)
+        if result:
+            _print_messages(result)
+
     @cmd.register('modify pool remove owning-user-group',
             help='unset owner group for POOLNAME')
     def modify_pool_set_owning_user_group(self, args):


### PR DESCRIPTION
Add functionality to move a pool to another layer3domain. With the move
all subnets all entries therein are moved as well.
All reverse entries are moved from heir current view to their new view
(named after the layer3domain by default).

Fixes #123