### PR TITLE
ndcli: allow listing containers in all layer3domains

### DIFF
--- a/dim-testsuite/t/container-autocorrect.t
+++ b/dim-testsuite/t/container-autocorrect.t
@@ -11,6 +11,7 @@ INFO - Creating container 10.30.2.0/23 in layer3domain default
 # Round down invalid CIDR
 $ ndcli list containers 10.30.3.0/23
 WARNING - 10.30.3.0/23 rounded to 10.30.2.0/23 because it is not a valid CIDR block
+layer3domain: default
 10.30.2.0/23 (Container)
   10.30.2.0/23 (Available)
 
@@ -18,18 +19,21 @@ WARNING - 10.30.3.0/23 rounded to 10.30.2.0/23 because it is not a valid CIDR bl
 $ ndcli list containers 192.168.0.0/12
 WARNING - 192.168.0.0/12 rounded to 192.160.0.0/12 because it is not a valid CIDR block
 WARNING - 192.160.0.0/12 rounded to 192.168.0.0/16 because no ipblock exists at 192.160.0.0/12 with status Container
+layer3domain: default
 192.168.0.0/16 (Container)
   192.168.0.0/16 (Available)
 
 # Round down valid CIDR because no container exists at that CIDR
 $ ndcli list containers 192.160.0.0/12
 WARNING - 192.160.0.0/12 rounded to 192.168.0.0/16 because no ipblock exists at 192.160.0.0/12 with status Container
+layer3domain: default
 192.168.0.0/16 (Container)
   192.168.0.0/16 (Available)
 
 # Round up valid CIDR because no container exists at that CIDR
 $ ndcli list containers 10.40.0.0/16
 WARNING - 10.40.0.0/16 rounded to 10.0.0.0/8 because no ipblock exists at 10.40.0.0/16 with status Container
+layer3domain: default
 10.0.0.0/8 (Container)
   10.0.0.0/12 (Available)
   10.16.0.0/13 (Available)

--- a/dim-testsuite/t/container-layer3domain.t
+++ b/dim-testsuite/t/container-layer3domain.t
@@ -23,19 +23,21 @@ modified_by:admin
 status:Container
 
 $ ndcli list containers
-ERROR - A layer3domain is needed
+layer3domain: one
+1.0.0.0/8 (Container) c:d
+  1.0.0.0/8 (Available)
 $ ndcli list containers layer3domain one
+layer3domain: one
 1.0.0.0/8 (Container) c:d
   1.0.0.0/8 (Available)
 $ ndcli list containers layer3domain one 1.0.0.0/8
+layer3domain: one
 1.0.0.0/8 (Container) c:d
   1.0.0.0/8 (Available)
 $ ndcli create layer3domain two type vrf rd 0:3
 $ ndcli create container 2.0.0.0/8 layer3domain two
 INFO - Creating container 2.0.0.0/8 in layer3domain two
 $ ndcli list containers layer3domain all
-layer3domain: default
-
 layer3domain: one
 1.0.0.0/8 (Container) c:d
   1.0.0.0/8 (Available)

--- a/dim-testsuite/t/container-list-2.t
+++ b/dim-testsuite/t/container-list-2.t
@@ -7,5 +7,6 @@ INFO - No zone found for localhost.server.lan.
 INFO - No zone found for 1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa.
 WARNING - No record was created because no forward or reverse zone found.
 $ ndcli list containers 0.0.0.0/8
+layer3domain: default
 0.0.0.0/8 (Container) comment:reserved reverse_dns_profile:internal source:RFC5735
   0.0.0.0/8 (Available)

--- a/dim-testsuite/t/container-list.t
+++ b/dim-testsuite/t/container-list.t
@@ -12,7 +12,25 @@ INFO - Creating container 10.0.0.0/8 in layer3domain one
 $ ndcli create container 11.0.0.0/8 layer3domain one
 INFO - Creating container 11.0.0.0/8 in layer3domain one
 $ ndcli list containers
-ERROR - A layer3domain is needed
+layer3domain: default
+10.0.0.0/8 (Container)
+  10.0.0.0/8 (Available)
+
+layer3domain: one
+10.0.0.0/8 (Container)
+  10.0.0.0/8 (Available)
+11.0.0.0/8 (Container)
+  11.0.0.0/8 (Available)
+$ ndcli list containers layer3domain all
+layer3domain: default
+10.0.0.0/8 (Container)
+  10.0.0.0/8 (Available)
+
+layer3domain: one
+10.0.0.0/8 (Container)
+  10.0.0.0/8 (Available)
+11.0.0.0/8 (Container)
+  11.0.0.0/8 (Available)
 $ ndcli list containers layer3domain default
 10.0.0.0/8 (Container)
   10.0.0.0/8 (Available)
@@ -20,5 +38,14 @@ $ ndcli list containers layer3domain default
 $ ndcli list containers layer3domain one
 10.0.0.0/8 (Container)
   10.0.0.0/8 (Available)
+11.0.0.0/8 (Container)
+  11.0.0.0/8 (Available)
+
+$ ndcli list containers layer3domain one 11.0.0.0/8
+11.0.0.0/8 (Container)
+  11.0.0.0/8 (Available)
+
+$ ndcli list containers layer3domain all 11.0.0.0/8
+layer3domain: one
 11.0.0.0/8 (Container)
   11.0.0.0/8 (Available)

--- a/dim-testsuite/t/container-list.t
+++ b/dim-testsuite/t/container-list.t
@@ -1,6 +1,9 @@
+# no output on no containers
+$ ndcli list containers
 $ ndcli create container 10.0.0.0/8
 INFO - Creating container 10.0.0.0/8 in layer3domain default
 $ ndcli list containers
+layer3domain: default
 10.0.0.0/8 (Container)
   10.0.0.0/8 (Available)
 
@@ -32,16 +35,19 @@ layer3domain: one
 11.0.0.0/8 (Container)
   11.0.0.0/8 (Available)
 $ ndcli list containers layer3domain default
+layer3domain: default
 10.0.0.0/8 (Container)
   10.0.0.0/8 (Available)
 
 $ ndcli list containers layer3domain one
+layer3domain: one
 10.0.0.0/8 (Container)
   10.0.0.0/8 (Available)
 11.0.0.0/8 (Container)
   11.0.0.0/8 (Available)
 
 $ ndcli list containers layer3domain one 11.0.0.0/8
+layer3domain: one
 11.0.0.0/8 (Container)
   11.0.0.0/8 (Available)
 

--- a/dim/dim/models/ip.py
+++ b/dim/dim/models/ip.py
@@ -381,10 +381,13 @@ class Ipblock(db.Model, WithAttr, TrackChanges):
             db.session.delete(block)
 
     @staticmethod
-    def query_ip(ip, layer3domain):
+    def query_ip(ip, layer3domain, status=None):
         filters = {}
         if layer3domain is not None:
             filters['layer3domain'] = layer3domain
+        if status is not None:
+            from dim.rpc import get_status
+            filters['status'] = get_status(status)
         return Ipblock.query.filter_by(address=ip.address,
                                        prefix=ip.prefix,
                                        version=ip.version,

--- a/dim/dim/rpc.py
+++ b/dim/dim/rpc.py
@@ -3425,7 +3425,6 @@ class RPC(object):
 
     @readonly
     def ipblock_get_attrs_multi(self, ipblock, layer3domain=None, full=False, filters = {}, **options):
-        logging.warn(filters)
         ip = parse_ip(ipblock)
         ipblocks = Ipblock.query_ip(ip, layer3domain, **filters)
         result = []

--- a/dim/dim/rpc.py
+++ b/dim/dim/rpc.py
@@ -3423,6 +3423,17 @@ class RPC(object):
                     and_(0 < has_access(False, True)).label('can_delete_rr')]
 
 
+    @readonly
+    def ipblock_get_attrs_multi(self, ipblock, layer3domain=None, full=False, filters = {}, **options):
+        logging.warn(filters)
+        ip = parse_ip(ipblock)
+        ipblocks = Ipblock.query_ip(ip, layer3domain, **filters)
+        result = []
+        for ipblock in ipblocks.all():
+            result.append(self.ipblock_get_attrs(ipblock, layer3domain=ipblock.layer3domain.name, full=full, **options))
+        return result
+
+
 def TRPC(*args, **kwargs):
     '''
     Returns an instance to a TransactionProxy class wrapping the public methods

--- a/ndcli/dimcli/__init__.py
+++ b/ndcli/dimcli/__init__.py
@@ -1607,12 +1607,20 @@ class CLI(object):
                 if 'children' in node:
                     print_tree(node['children'], level + 1)
 
-        layer3domains = [args.layer3domain]
-        if args.layer3domain == "all":
-            layer3domains = [l['name'] for l in self.client.layer3domain_list()]
+        if args.layer3domain == "all" or get_layer3domain(args.layer3domain) is None:
+            force_print_layer3domain = True
+            if args.container:
+                filters = dict(status=['Container'])
+                blocks = self.client.ipblock_get_attrs_multi(args.container, filters=filters)
+                layer3domains = [block['layer3domain'] for block in blocks]
+            else:
+                layer3domains = [l['name'] for l in self.client.layer3domain_list()]
+        else:
+            force_print_layer3domain = False
+            layer3domains = [args.layer3domain]
 
         for idx, layer3domain in enumerate(layer3domains):
-            if len(layer3domains) > 1:
+            if len(layer3domains) > 1 or (len(self.client.layer3domain_list()) >1 and force_print_layer3domain):
                 if idx > 0:
                     print()
                 print('layer3domain: ' + layer3domain)

--- a/ndcli/dimcli/__init__.py
+++ b/ndcli/dimcli/__init__.py
@@ -8,6 +8,8 @@ import sys
 import textwrap
 from datetime import datetime
 from functools import wraps
+from typing import List
+from collections import OrderedDict
 
 from operator import itemgetter
 
@@ -15,7 +17,7 @@ from . import zoneimport
 from .cliparse import Command, Option, Group, Argument, Token
 from . import version
 
-from dimclient import DimClient
+from dimclient import DimClient, DimError
 
 __version__ = version.VERSION
 
@@ -1597,7 +1599,7 @@ class CLI(object):
                   Argument('container', nargs='?'),
                   help='list the children of a container')
     def list_containers(self, args):
-        def print_tree(tree, level):
+        def print_tree(tree, level: int):
             for node in tree:
                 attributes = ['(%s)' % node['status']]
                 if 'pool' in node:
@@ -1606,30 +1608,42 @@ class CLI(object):
                 print('  ' * level + '%s %s' % (node['ip'], ' '.join(attributes)))
                 if 'children' in node:
                     print_tree(node['children'], level + 1)
-
+        layer3domains: List[str] = []
         if args.layer3domain == "all" or get_layer3domain(args.layer3domain) is None:
-            force_print_layer3domain = True
-            if args.container:
-                filters = dict(status=['Container'])
-                blocks = self.client.ipblock_get_attrs_multi(args.container, filters=filters)
-                layer3domains = [block['layer3domain'] for block in blocks]
-            else:
-                layer3domains = [l['name'] for l in self.client.layer3domain_list()]
+            layer3domains = [l['name'] for l in self.client.layer3domain_list()]
         else:
-            force_print_layer3domain = False
-            layer3domains = [args.layer3domain]
-
-        for idx, layer3domain in enumerate(layer3domains):
-            if len(layer3domains) > 1 or (len(self.client.layer3domain_list()) >1 and force_print_layer3domain):
-                if idx > 0:
-                    print()
-                print('layer3domain: ' + layer3domain)
+            layer3domains = [get_layer3domain(args.layer3domain)]
+        # loop through layer3domains and collect results,
+        # so we can raise an error if there are no results at all
+        results = OrderedDict()
+        dim_errors = []
+        for layer3domain in layer3domains:
             options = OptionDict(include_messages=True)
             options.set_if(container=args.container)
             options.set_if(layer3domain=layer3domain)
-            result = self.client.container_list(**options)
+            try:
+                results[layer3domain] = self.client.container_list(**options)
+            except Exception as e:
+                if e.code == 3: # InvalidIPError
+                    dim_errors.append(e)
+                    next
+                else:
+                    raise
+        if len(dim_errors) == len(layer3domains):
+            # raise an error if there are no results at all
+            raise DimError('; '.join([str(e) for e in dim_errors]), code=3) # InvalidIPError
+        elif len(dim_errors) > 0:
+            for dimerror in dim_errors:
+                logging.debug(dimerror)
+        idx = 0
+        for layer3domain, result in results.items():
+            if idx > 0:
+                print()
             _print_messages(result)
-            print_tree(result['containers'], 0)
+            if result['containers']:
+                print('layer3domain: ' + layer3domain)
+                print_tree(result['containers'], 0)
+                idx += 1
 
     @cmd.register('list ips',
                   Argument('query', metavar='VLANID|CIDR|POOL'),


### PR DESCRIPTION
extend list containers to support listing containers
for all layer3domains

also take user's configured layer3domain into account, via `get_layer3domain()`

always print the layer3domain for `ndcli list containers` to avoid confusion with the output as the user can configure the layer3domain in various places (environment variable, config), that don't show up in the command-line.

only print the layer3domain (name) if it actually has containers