### PR TITLE
dim-testsuite: add more make targets

### DIFF
--- a/dim-testsuite/Makefile
+++ b/dim-testsuite/Makefile
@@ -3,6 +3,8 @@ VDIR           ?= virtual_env
 ODIR           ?= out
 VPIP           ?= ${VDIR}/bin/pip3
 VPYTHON        ?= ${VDIR}/bin/python3
+VPYTEST        ?= ${VDIR}/bin/pytest
+VPYTESTS       ?= .
 LDIR           ?= log
 SRVLOG         ?= ${LDIR}/server.log
 NDCLI_USERNAME ?= admin
@@ -14,23 +16,37 @@ all: install db test
 	mkdir ${OUTDIR}
 	mkdir ${LDIR}
 
-install:
+install-deps:
 	${PYTHON} -m venv ${VDIR}
 	${VPIP} install -r ../dim/requirements.txt
+	${VPIP} install -r ../ndcli/requirements.txt
+
+install-deps-local: install-deps
+	${VPIP} install ../dim
+	${VPIP} install ../dimclient
+	${VPIP} install ../ndcli
+
+install-deps-local-editable: install-deps
 	${VPIP} install -e ../dim
 	${VPIP} install -e ../dimclient
-	${VPIP} install -r ../ndcli/requirements.txt
 	${VPIP} install -e ../ndcli
 
-db:
-	mysql -h127.0.0.1 -P3307 -updns -ppdns pdns1 < ./testenv/pdns.sql
-	mysql -h127.0.0.1 -P3307 -updns -ppdns pdns2 < ./testenv/pdns.sql
+install: install-deps-local
+
+install-dev: install-deps-local-editable
+	${VPIP} install -r ../dim/requirements-dev.txt
+	${VPIP} install -r ../ndcli/requirements-dev.txt
+
+db-clear:
 	${VDIR}/bin/manage_db clear
 
-test:
+db: db-clear
+	mysql -h127.0.0.1 -P3307 -updns -ppdns pdns1 < ./testenv/pdns.sql
+	mysql -h127.0.0.1 -P3307 -updns -ppdns pdns2 < ./testenv/pdns.sql
+
+test: db-clear
 	-mkdir ${ODIR}
 	-mkdir ${LDIR}
-	${VDIR}/bin/manage_db clear
 
 	PATH="${VDIR}/bin:${PATH}" \
 		TEST_OUTPUT_DIR="${ODIR}" \
@@ -39,5 +55,8 @@ test:
 		NDCLI_CONFIG="${NDCLI_CONFIG}" \
 		NDCLI_SERVER="${NDCLI_SERVER}" \
 		${VPYTHON} runtest.py -d ${TESTS}
+
+pytest: db-clear
+	${VPYTEST} -k ${PYTESTS}
 
 .PHONY: db test install clean

--- a/dim-testsuite/Makefile
+++ b/dim-testsuite/Makefile
@@ -44,7 +44,7 @@ db: db-clear
 	mysql -h127.0.0.1 -P3307 -updns -ppdns pdns1 < ./testenv/pdns.sql
 	mysql -h127.0.0.1 -P3307 -updns -ppdns pdns2 < ./testenv/pdns.sql
 
-test: db-clear
+test:
 	-mkdir ${ODIR}
 	-mkdir ${LDIR}
 
@@ -56,7 +56,7 @@ test: db-clear
 		NDCLI_SERVER="${NDCLI_SERVER}" \
 		${VPYTHON} runtest.py -d ${TESTS}
 
-pytest: db-clear
+pytest:
 	${VPYTEST} -k ${PYTESTS}
 
 .PHONY: db test install clean

--- a/dim/dim/__init__.py
+++ b/dim/dim/__init__.py
@@ -42,6 +42,10 @@ def create_app(db_mode=None, testing=False):
     app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
     if db_mode:
         app.config['SQLALCHEMY_DATABASE_URI'] = app.config['SQLALCHEMY_DATABASE_URI_' + db_mode]
+
+    if testing:
+        app.config['LAYER3DOMAIN_WHITELIST'] = app.config.get('LAYER3DOMAIN_WHITELIST', ['10.0.0.0/8', '176.16.0.0/12', '192.168.0.0/16'])
+
     if 'LAYER3DOMAIN_WHITELIST' not in app.config:
         logging.error('LAYER3DOMAIN_WHITELIST not set')
         sys.exit(1)

--- a/dim/requirements-dev.txt
+++ b/dim/requirements-dev.txt
@@ -1,6 +1,6 @@
-nose
-nose-ignore-docstring
-pytest
-pytest-cov
-ipython
-sphinx
+nose~=1.3
+nose-ignore-docstring~=0.2
+click~=7.1
+pytest~=6.2
+pytest-cov~=3.0
+Sphinx~=4.4

--- a/dim/requirements.txt
+++ b/dim/requirements.txt
@@ -4,7 +4,6 @@ ldap3~=2.9
 Werkzeug>=0.15.3
 Flask~=1.1
 Flask-SQLAlchemy~=2.5
-click~=7.1
 Jinja2~=2.11
 Flask-Script~=2.0
 dnspython~=2.1

--- a/dim/requirements.txt
+++ b/dim/requirements.txt
@@ -4,6 +4,7 @@ ldap3~=2.9
 Werkzeug>=0.15.3
 Flask~=1.1
 Flask-SQLAlchemy~=2.5
+click~=7.1
 Jinja2~=2.11
 Flask-Script~=2.0
 dnspython~=2.1

--- a/ndcli/requirements-dev.txt
+++ b/ndcli/requirements-dev.txt
@@ -1,2 +1,2 @@
-sphinx>=1.0
-hypothesis==5.6.0
+Sphinx~=4.4
+hypothesis~=5.6.0


### PR DESCRIPTION
* add more reusable targets and add some dependencies
* add a separate target for editable pip install
* add target for pytest
* stricter requirements for deps

Adding a separate target for the editable pip install,
as that causes issues with e.g. read-only bind mounts
of the code in containers, as editable install adds
files to the *source* tree.

Adding the `pytest` suite to run the unit tests,
add default `LAYER3DOMAIN_WHITELIST` when running
with `testing` enabled, so the `pytest` tests can run.

Specifying stricter versions so `pip` can resolve the
dependencies in a timely fashion.
It complained
```This is taking longer than usual.
You might need to provide the dependency resolver
with stricter constraints to reduce runtime.
```
and would not complete within 15 minutes.