### PR TITLE
replace deprecated getargspec function

### DIFF
--- a/dim/dim/models/rights.py
+++ b/dim/dim/models/rights.py
@@ -130,7 +130,7 @@ def permission(func):
             return
         if not func(self, *args):
             import inspect
-            argspec = inspect.getargspec(func).args
+            argspec = inspect.getfullargspec(func).args
             if 'type' in argspec:
                 args = args[0:argspec.index('type') - 1] + args[argspec.index('type'):]
             reason = ' '.join(str(a) for a in (func.__name__, ) + args)


### PR DESCRIPTION
>DeprecationWarning: inspect.getargspec() is deprecated since Python 3.0

https://docs.python.org/3/library/inspect.html#inspect.getargspec

Use drop-in replacement `getfullargspec()`