### PR TITLE
list pool: order subnets by priority

### DIFF
--- a/dim-testsuite/t/pool-list-4.t
+++ b/dim-testsuite/t/pool-list-4.t
@@ -1,0 +1,52 @@
+# verify a pool's subnets are listed ordered by priority
+$ ndcli create pool some-pool
+$ ndcli create container 10.0.0.0/8
+INFO - Creating container 10.0.0.0/8 in layer3domain default
+$ ndcli modify pool some-pool add subnet 10.0.0.0/24
+INFO - Created subnet 10.0.0.0/24 in layer3domain default
+WARNING - Creating zone 0.0.10.in-addr.arpa without profile
+WARNING - Primary NS for this Domain is now localhost.
+$ ndcli list pool some-pool
+INFO - Total free IPs: 254
+prio subnet      gateway free total
+   1 10.0.0.0/24         254   256
+
+$ ndcli modify pool some-pool add subnet 10.0.9.0/24
+INFO - Created subnet 10.0.9.0/24 in layer3domain default
+WARNING - Creating zone 9.0.10.in-addr.arpa without profile
+WARNING - Primary NS for this Domain is now localhost.
+
+$ ndcli modify pool some-pool add subnet 10.0.5.0/24
+INFO - Created subnet 10.0.5.0/24 in layer3domain default
+WARNING - Creating zone 5.0.10.in-addr.arpa without profile
+WARNING - Primary NS for this Domain is now localhost.
+
+$ ndcli list pool some-pool
+INFO - Total free IPs: 762
+prio subnet      gateway free total
+   1 10.0.0.0/24          254   256
+   2 10.0.9.0/24          254   256
+   3 10.0.5.0/24          254   256
+
+$ ndcli modify pool some-pool add subnet 10.0.10.0/24
+INFO - Created subnet 10.0.10.0/24 in layer3domain default
+WARNING - Creating zone 10.0.10.in-addr.arpa without profile
+WARNING - Primary NS for this Domain is now localhost.
+
+$ ndcli list pool some-pool
+INFO - Total free IPs: 1016
+prio subnet      gateway free total
+   1 10.0.0.0/24          254   256
+   2 10.0.9.0/24          254   256
+   3 10.0.5.0/24          254   256
+   4 10.0.10.0/24         254   256
+
+$ ndcli modify pool some-pool subnet 10.0.10.0/24 set prio 1
+
+$ ndcli list pool some-pool
+INFO - Total free IPs: 1016
+prio subnet       gateway free total
+   1 10.0.10.0/24          254   256
+   2 10.0.0.0/24           254   256
+   3 10.0.9.0/24           254   256
+   4 10.0.5.0/24           254   256

--- a/dim-testsuite/tests/util.py
+++ b/dim-testsuite/tests/util.py
@@ -48,10 +48,11 @@ class DatabaseTest(unittest.TestCase):
         if not (missing or mismatched):
             return
 
+        msg = ''
         if missing:
-            msg = 'Missing: %s' % ','.join(safe_repr(m) for m in missing)
+            msg += 'Missing: %s' % ','.join(safe_repr(m) for m in missing)
         if mismatched:
-            if msg:
+            if len(msg) > 0:
                 msg += '; '
             msg += 'Mismatched values: %s' % ','.join(mismatched)
         self.fail(msg)

--- a/dim/dim/models/ip.py
+++ b/dim/dim/models/ip.py
@@ -120,7 +120,7 @@ class Pool(db.Model, WithAttr):
     vlan = relationship(Vlan)
     owner = relationship('Group')
     layer3domain = relationship(Layer3Domain)
-    ipblocks = relationship("Ipblock", backref="pool")
+    ipblocks = relationship("Ipblock", backref="pool", order_by='Ipblock.priority')
     subnets = synonym('ipblocks')
 
     @property


### PR DESCRIPTION
adjust the db model for `Pool` to return the list of subnets
sorted by priority, which prohbably is what a user expects in general

additionally, fix the test function `assertDictSubset()` to make sure msg is a string,
as it would sometimes fail, see #198

resolves #168