### PR TITLE
order rr references by id

### DIFF
--- a/dim/dim/rpc.py
+++ b/dim/dim/rpc.py
@@ -2622,7 +2622,7 @@ class RPC(object):
                         not (not delete and ref.type not in IP_RELATED and rr.type not in IP_RELATED and root.type in IP_RELATED):
                     nodes.append(ref)
                     graph[rr.id].append(ref.id)
-        return {'records': [rr_object(records[r]) for r in records], 'graph': graph, 'root': root.id}
+        return {'records': sorted([rr_object(records[r]) for r in records], key=lambda x: x['id']), 'graph': graph, 'root': root.id}
 
     @updating
     def rr_edit(self, id, views=None, references=None, **kwargs):


### PR DESCRIPTION
make order for reference records returned by `rr_get_references()`
persistent/predictable by sorting them by their `id` attribute

this makes `RRReferencesTest::test_get_references` work, see #198