### PR TITLE
rpc/ippool_count: support layer3domain

### DIFF
--- a/dim/dim/rpc.py
+++ b/dim/dim/rpc.py
@@ -1009,8 +1009,8 @@ class RPC(object):
         get_pool(old_name).name = new_name
 
     @readonly
-    def ippool_count(self, pool=None, vlan=None, cidr=None, can_allocate=None, owner=None):
-        return self._ippool_query(pool, vlan=vlan, cidr=cidr, can_allocate=can_allocate, owner=owner).count()
+    def ippool_count(self, pool=None, vlan=None, cidr=None, can_allocate=None, owner=None, layer3domain=None):
+        return self._ippool_query(pool, vlan=vlan, cidr=cidr, can_allocate=can_allocate, owner=owner, layer3domain=layer3domain).count()
 
     @readonly
     def ippool_list(self, pool=None, vlan=None, cidr=None, full=False, include_subnets=True,


### PR DESCRIPTION
expose layer3domain as parameter for `ippool_count()` and pass it on, to allow filtering by layer3domain

this fixes a regression introduced in #193, which added a new required parameter to `_ippool_query()`:
`FAILED tests/pool_test.py::PoolTest::test_list_ippools_pagination - TypeError: RPC._ippool_query() missing 1 required positional argument: 'layer3domain'`