### PR TITLE
dim - fix layer3domain being ignored when allocating IP

### DIFF
--- a/dim-testsuite/t/ippool-reserve-overlapping.t
+++ b/dim-testsuite/t/ippool-reserve-overlapping.t
@@ -1,0 +1,38 @@
+$ ndcli create layer3domain foo type foo
+$ ndcli create layer3domain bar type bar
+$ ndcli create pool foo layer3domain foo
+$ ndcli create pool bar layer3domain bar
+$ ndcli create container 192.168.0.0/16 layer3domain foo
+INFO - Creating container 192.168.0.0/16 in layer3domain foo
+$ ndcli create container 192.168.0.0/16 layer3domain bar
+INFO - Creating container 192.168.0.0/16 in layer3domain bar
+$ ndcli modify pool foo add subnet 192.168.42.0/24
+INFO - Created subnet 192.168.42.0/24 in layer3domain foo
+WARNING - Creating zone 42.168.192.in-addr.arpa without profile
+WARNING - Primary NS for this Domain is now localhost.
+$ ndcli modify pool bar add subnet 192.168.42.0/24 --allow-overlap
+INFO - Created subnet 192.168.42.0/24 in layer3domain bar
+WARNING - 192.168.42.0/24 in layer3domain bar overlaps with 192.168.42.0/24 in layer3domain foo
+INFO - Creating view bar in zone 42.168.192.in-addr.arpa without profile
+$ ndcli modify pool foo get ip
+created:2021-12-15 08:35:07.369708
+ip:192.168.42.1
+layer3domain:foo
+mask:255.255.255.0
+modified:2021-12-15 08:35:07.369724
+modified_by:admin
+pool:foo
+reverse_zone:42.168.192.in-addr.arpa
+status:Static
+subnet:192.168.42.0/24
+$ ndcli modify pool bar get ip
+created:2022-02-09 10:40:26.140923
+ip:192.168.42.1
+layer3domain:bar
+mask:255.255.255.0
+modified:2022-02-09 10:40:26.140939
+modified_by:admin
+pool:bar
+reverse_zone:42.168.192.in-addr.arpa
+status:Static
+subnet:192.168.42.0/24

--- a/dim/dim/rpc.py
+++ b/dim/dim/rpc.py
@@ -1432,7 +1432,7 @@ class RPC(object):
     @updating
     def ippool_get_ip(self, pool, attributes=None, full=False):
         pool = get_pool(pool)
-        ipblock = self._ip_mark(allocate_ip(pool), attributes=attributes, pool=pool)
+        ipblock = self._ip_mark(allocate_ip(pool), layer3domain=pool.layer3domain, attributes=attributes, pool=pool)
         if ipblock:
             return self.ipblock_get_attrs(ipblock, full=full)
 


### PR DESCRIPTION
When getting a new IP from a pool that has an overlapping IP range with
another layer3domain it was possible that get ip was blocking that
request.
The cause was that the layer3domain wasn't added to the function to mark
the IP.

Fixes #162