### PR TITLE
fix rr-create-txt-2

### DIFF
--- a/dim-testsuite/t/rr-create-txt-2.t
+++ b/dim-testsuite/t/rr-create-txt-2.t
@@ -12,17 +12,17 @@ $ ndcli create rr t.a.de. txt a
 WARNING - The name t.a.de. already existed, creating round robin record
 INFO - Creating RR t TXT "a" in zone a.de
 $ ndcli list rrs t.a.de.
+INFO - Result for list rrs t.a.de.
 record zone view    ttl type value
 t      a.de default     TXT  "\""
 t      a.de default     TXT  "\"\\\223"
 t      a.de default     TXT  "a"
-INFO - Result for list rrs t.a.de.
 $ ndcli delete rr t.a.de. txt '"'
 ERROR - Expected " at the end of: "
 $ ndcli delete rr t.a.de. txt '\"'
 INFO - Deleting RR t TXT "\"" from zone a.de
 $ ndcli list rrs t.a.de.
+INFO - Result for list rrs t.a.de.
 record zone view    ttl type value
 t      a.de default     TXT  "\"\\\223"
 t      a.de default     TXT  "a"
-INFO - Result for list rrs t.a.de.

--- a/dim-testsuite/tests/dns_test.py
+++ b/dim-testsuite/tests/dns_test.py
@@ -573,6 +573,9 @@ class TXT(RPCTest):
         RPCTest.setUp(self)
         self.r.zone_create('test.com')
 
+    def _simple_quote(self, txt: str):
+        return '"' + txt + '"'
+
     def test_parse(self):
         for txt in ('unquoted', '"', '\\"', '\\', '"\\"', '"\\', '"\\0"', '"\\999"', 'a"b"', '"a"b', '"""', '"\\\\\\"'):
             with raises(InvalidParameterError):
@@ -584,7 +587,11 @@ class TXT(RPCTest):
                      '""': '',
                      '"" "a"': '"a"',
                      '"a" ""': '"a"',
-                     r'"\\" "\"" "\223"': r'"\\" "\"" "\223"'}
+                     r'"\\" "\"" "\223"': r'"\\" "\"" "\223"',
+                      # splitting values longer than 255 bytes
+                     self._simple_quote('a' * 255): self._simple_quote('a' * 255),
+                     self._simple_quote('a' * 256): ' '.join([self._simple_quote('a' * 255), self._simple_quote('a' * 1)]),
+                     self._simple_quote('a' * 513): ' '.join([self._simple_quote('a' * 255), self._simple_quote('a' * 255), self._simple_quote('a' * 3)])}
         for i, original in enumerate(canonical.keys()):
             rr_name = '%d.test.com.' % i
             self.r.rr_create(name=rr_name, type='TXT', strings=original)


### PR DESCRIPTION
adjust expected output to current ndcli behaviour/order

add pytests for txt record splitting

relates to #72