### PR TITLE
do not use dnspython 2.2.0

### DIFF
--- a/dim/requirements.txt
+++ b/dim/requirements.txt
@@ -6,7 +6,7 @@ Flask~=1.1
 Flask-SQLAlchemy~=2.5
 Jinja2~=2.11
 Flask-Script~=2.0
-dnspython~=2.1
+dnspython~=2.1,!=2.2.0
 simplejson~=3.17
 requests~=2.25
 pycryptodome~=3.10

--- a/ndcli/requirements.txt
+++ b/ndcli/requirements.txt
@@ -1,2 +1,2 @@
 python-dateutil>=1.4.1
-dnspython>=1.12.0
+dnspython>=1.12.0,!=2.2.0


### PR DESCRIPTION
dnspython breaks at least the zone import tests in `zone-import-arpa.t`, fails with `ERROR - add() has non-origin SOA`

see https://github.com/rthalley/dnspython/issues/766

the upstream fix should make it into 2.2.1