### PR TITLE
dim - allow network and dns permissions on same group

### DIFF
--- a/dim-testsuite/t/rights-same-group.t
+++ b/dim-testsuite/t/rights-same-group.t
@@ -16,8 +16,6 @@ $ ndcli modify user-group network-admins add user networkadmin
 $ ndcli create user-group receiver
 $ ndcli modify user-group receiver add user receiver
 $ ndcli create user-group blocker
-$ ndcli create user-group department
-$ ndcli modify user-group department set department 674832
 
 $ ndcli create zone example.com
 WARNING - Creating zone example.com without profile

--- a/dim-testsuite/t/rights-same-group.t
+++ b/dim-testsuite/t/rights-same-group.t
@@ -1,0 +1,43 @@
+# make sure the users exist
+# as user dnsadmin
+$ ndcli login -u dnsadmin -p p
+# as user networkadmin
+$ ndcli login -u networkadmin -p p
+# as user receiver
+$ ndcli login -u receiver -p p
+
+# as user admin
+$ ndcli create user-group dns-admins
+$ ndcli modify user-group dns-admins grant dns_admin
+$ ndcli modify user-group dns-admins add user dnsadmin
+$ ndcli create user-group network-admins
+$ ndcli modify user-group network-admins grant network_admin
+$ ndcli modify user-group network-admins add user networkadmin
+$ ndcli create user-group receiver
+$ ndcli modify user-group receiver add user receiver
+$ ndcli create user-group blocker
+$ ndcli create user-group department
+$ ndcli modify user-group department set department 674832
+
+$ ndcli create zone example.com
+WARNING - Creating zone example.com without profile
+WARNING - Primary NS for this Domain is now localhost.
+
+# allocat permission
+$ ndcli create container 10.0.0.0/8
+INFO - Creating container 10.0.0.0/8 in layer3domain default
+$ ndcli create pool a
+$ ndcli modify pool a add subnet 10.0.0.0/24
+INFO - Created subnet 10.0.0.0/24 in layer3domain default
+WARNING - Creating zone 0.0.10.in-addr.arpa without profile
+WARNING - Primary NS for this Domain is now localhost.
+
+# set correct permissions
+$ ndcli -u networkadmin modify user-group receiver grant allocate a
+$ ndcli -u dnsadmin modify user-group receiver grant create_rr example.com
+
+# ensure networking and dns permissions are still blocked
+$ ndcli -u networkadmin modify user-group blocker grant create_rr example.com
+ERROR - Permission denied (can_dns_admin)
+$ ndcli -u dnsadmin modify user-group receiver grant allocate a
+ERROR - Permission denied (can_network_admin)

--- a/dim/dim/models/rights.py
+++ b/dim/dim/models/rights.py
@@ -231,11 +231,7 @@ class User(db.Model):
         if group.is_network_admin or group.is_dns_admin:
             return False
         is_network_admin = self.has_any_access([('network_admin', None)])
-        if group.network_rights and not is_network_admin:
-            return False
         is_dns_admin = self.has_any_access([('dns_admin', None)])
-        if group.dns_rights and not is_dns_admin:
-            return False
         return is_network_admin or is_dns_admin
 
     @permission


### PR DESCRIPTION
Fixes #171

A user had to be in different groups to receive network and dns
permissions.
With this change a user can be in a single group and receive network and
dns permissions.

This should also work for groups in departments. As these can't be
created via DIM, this can not be tested though.