### PR TITLE
dim - allow NULL MX records (RFC7505)

### DIFF
--- a/dim-testsuite/t/rr-create-mx-1.t
+++ b/dim-testsuite/t/rr-create-mx-1.t
@@ -47,9 +47,9 @@ rootserver a.de       MX    10 mx00.example.com.
 # rfc1035 states "PREFERENCE A 16 bit integer....." it does not say explicitly signed or unsigned
 # for our use i specify min value 1 max value 2^15-1
 $ ndcli create rr m.a.de. mx 0 mx
-ERROR - Preference min 1 max 32767
+ERROR - Preference min 1 max 32767 or 0 with exchange "."
 $ ndcli create rr m.a.de. mx 32768 mx
-ERROR - Preference min 1 max 32767
+ERROR - Preference min 1 max 32767 or 0 with exchange "."
 
 $ ndcli delete zone a.de --cleanup
 INFO - Deleting RR @ MX 10 mx from zone a.de

--- a/dim-testsuite/t/rr-create-mx-3.t
+++ b/dim-testsuite/t/rr-create-mx-3.t
@@ -32,7 +32,7 @@ ERROR - NULL MX records can not coexist with normal MX records
 $ ndcli delete rr a.de. mx -q
 
 $ ndcli create rr a.de. mx 0 .
-INFO - Creating RR @ MX 0. in zone a.de
+INFO - Creating RR @ MX 0 . in zone a.de
 WARNING - . does not exist.
 
 # Try to create a MX in parallel to a NULL MX -> fail

--- a/dim-testsuite/t/rr-create-mx-3.t
+++ b/dim-testsuite/t/rr-create-mx-3.t
@@ -27,7 +27,7 @@ WARNING - mx.outside.zone. does not exist.
 
 # Try to create a NULL MX -> must fail
 $ ndcli create rr a.de. mx 0 .
-ERROR - NULL MX records can not coexist with normal MX records
+ERROR - Can not create NULL MX record - other MX record already exists
 
 $ ndcli delete rr a.de. mx -q
 
@@ -37,7 +37,7 @@ WARNING - . does not exist.
 
 # Try to create a MX in parallel to a NULL MX -> fail
 $ ndcli create rr a.de. mx 10 mx.outside.zone.
-ERROR - NULL MX records can not coexist with normal MX records
+ERROR - Can not create MX record - NULL MX record already exists
 
 $ ndcli delete zone a.de --cleanup -q
 $ ndcli delete zone 3.2.1.in-addr.arpa --cleanup

--- a/dim/dim/dns.py
+++ b/dim/dim/dns.py
@@ -228,13 +228,14 @@ def create_single_rr(name, rr_type, zone, view, user, overwrite=False, **kwargs)
                 existed = True
                 Messages.info("%s already exists" % samerr)
             else:
+                logging.info('WOOOOSA %s -> %s -> %s', new_rr, samerr, rrs)
                 if rr_type == 'PTR':  # Don't allow PTR round robin records
                     created = False
                     Messages.warn("Not overwriting: %s" % rrs[0])
-                elif rr_type == 'MX' and (new_rr.target == '.' and samerr):
-                    raise DimError('NULL MX records can not coexist with normal MX records')
-                elif rr_type == 'MX' and RR.query.filter(RR.name == new_rr.name and RR.view == view and RR.target == '.').count() > 0:
-                    raise DimError('NULL MX records can not coexist with normal MX records')
+                elif rr_type == 'MX' and (new_rr.target == '.' and len(rrs) > 0):
+                    raise DimError('Can not create NULL MX record - other MX record already exists')
+                elif rr_type == 'MX' and RR.query.filter(RR.name == new_rr.name, RR.type == 'MX', RR.view == view, RR.target == '.').count() > 0:
+                    raise DimError('Can not create MX record - NULL MX record already exists')
                 else:
                     Messages.warn("The name %s already existed, creating round robin record" % name)
     if created:

--- a/dim/dim/dns.py
+++ b/dim/dim/dns.py
@@ -228,7 +228,6 @@ def create_single_rr(name, rr_type, zone, view, user, overwrite=False, **kwargs)
                 existed = True
                 Messages.info("%s already exists" % samerr)
             else:
-                logging.info('WOOOOSA %s -> %s -> %s', new_rr, samerr, rrs)
                 if rr_type == 'PTR':  # Don't allow PTR round robin records
                     created = False
                     Messages.warn("Not overwriting: %s" % rrs[0])

--- a/dim/dim/dns.py
+++ b/dim/dim/dns.py
@@ -231,6 +231,10 @@ def create_single_rr(name, rr_type, zone, view, user, overwrite=False, **kwargs)
                 if rr_type == 'PTR':  # Don't allow PTR round robin records
                     created = False
                     Messages.warn("Not overwriting: %s" % rrs[0])
+                elif rr_type == 'MX' and (new_rr.target == '.' and samerr):
+                    raise DimError('NULL MX records can not coexist with normal MX records')
+                elif rr_type == 'MX' and RR.query.filter(RR.name == new_rr.name and RR.view == view and RR.target == '.').count() > 0:
+                    raise DimError('NULL MX records can not coexist with normal MX records')
                 else:
                     Messages.warn("The name %s already existed, creating round robin record" % name)
     if created:

--- a/dim/dim/models/dns.py
+++ b/dim/dim/models/dns.py
@@ -366,7 +366,7 @@ class RR(db.Model, TrackChanges):
         rr_class = RR.get_class(type)
         try:
             for field, validate in list(rr_class.validate.items()):
-                kwargs[field] = validate(None, field, kwargs[field])
+                kwargs[field] = validate(None, field, kwargs[field], **({i:kwargs[i] for i in kwargs if i != field}))
         except ValueError as e:
             raise InvalidParameterError(str(e))
         return kwargs

--- a/dim/dim/rrtype.py
+++ b/dim/dim/rrtype.py
@@ -19,7 +19,7 @@ def label_is_valid(label):
     return True
 
 
-def validate_fqdn(self, key, value):
+def validate_fqdn(self, key, value, **kwargs):
     if value == '.':
         return value
     if not value.endswith('.'):
@@ -33,7 +33,7 @@ def validate_fqdn(self, key, value):
     return value
 
 
-def validate_mail(self, key, value):
+def validate_mail(self, key, value, **kwargs):
     if '.' not in value[:-1]:
         raise InvalidParameterError('Invalid %s: %s' % (key, value))
     try:
@@ -44,7 +44,7 @@ def validate_mail(self, key, value):
     return value.lower()
 
 
-def validate_target(self, key, value, preference=None):
+def validate_target(self, key, value, preference=None, **kwargs):
     if len(value) > 254:
         raise InvalidParameterError('Invalid %s: %s' % (key, value))
     value = value.lower()
@@ -61,21 +61,21 @@ def validate_target(self, key, value, preference=None):
     return value
 
 
-def validate_uint8(self, key, value):
+def validate_uint8(self, key, value, **kwargs):
     value = int(value)
     if value < 0 or value > 2 ** 8 - 1:
         raise InvalidParameterError("Invalid %s: %d" % (key, value))
     return value
 
 
-def validate_uint16(self, key, value):
+def validate_uint16(self, key, value, **kwargs):
     value = int(value)
     if value < 0 or value > 2 ** 16 - 1:
         raise InvalidParameterError("Invalid %s: %d" % (key, value))
     return value
 
 
-def validate_uint32(self, key, value):
+def validate_uint32(self, key, value, **kwargs):
     value = int(value)
     if value < 0 or value > 2 ** 32 - 1:
         raise InvalidParameterError("Invalid %s: %d" % (key, value))
@@ -91,20 +91,20 @@ def validate_preference(self, key, value, exchange=None):
     return value
 
 
-def validate_certificate(self, key, value):
+def validate_certificate(self, key, value, **kwargs):
     if ' ' in value:
         raise InvalidParameterError("Invalid %s: %s" % (key, value))
     return value
 
 
-def validate_hexstring(self, key, value):
+def validate_hexstring(self, key, value, **kwargs):
     if ' ' in value or not re.match('^[0-9a-fA-F]*$', value) or len(value) % 2 != 0:
         raise InvalidParameterError("Invalid %s: %s" % (key, value))
     return value
 
 
 def validate_enum(enum, reserved=None):
-    def f(self, key, value):
+    def f(self, key, value, **kwargs):
         try:
             value = int(value)
         except:
@@ -123,7 +123,7 @@ def validate_enum(enum, reserved=None):
     return f
 
 
-def validate_caa_flags(self, key, value):
+def validate_caa_flags(self, key, value, **kwargs):
     try:
         value = int(value)
         if value not in (0, 1, 128):
@@ -133,7 +133,7 @@ def validate_caa_flags(self, key, value):
         raise InvalidParameterError('CAA Issuer critical only allows values 0, 1, 128')
 
 
-def validate_property_tag(self, key, value):
+def validate_property_tag(self, key, value, **kwargs):
     value = value.lower()
     if value not in ("issue", "issuewild", "iodef"):
         raise InvalidParameterError('only CAA property tags "issue", "issuewild", "iodef" are allowed')
@@ -208,7 +208,7 @@ def _parse_strings(value):
     return strings
 
 
-def validate_strings(self, key, value: Union[str, List[str]]):
+def validate_strings(self, key, value: Union[str, List[str]], **kwargs):
     if isinstance(value, str):
         strings = _parse_strings(value)
     elif isinstance(value, list):
@@ -230,7 +230,7 @@ def validate_strings(self, key, value: Union[str, List[str]]):
     return ' '.join('"' + dns.rdata._escapify(s) + '"' for s in split_strings)
 
 
-def validate_character_string(self, key, value):
+def validate_character_string(self, key, value, **kwargs):
     if len(_unescapify(value)) > 255:
         raise ValueError('Invalid %s: character string too long' % key)
     return '"%s"' % value

--- a/dim/dim/rrtype.py
+++ b/dim/dim/rrtype.py
@@ -44,10 +44,12 @@ def validate_mail(self, key, value):
     return value.lower()
 
 
-def validate_target(self, key, value):
+def validate_target(self, key, value, preference=None):
     if len(value) > 254:
         raise InvalidParameterError('Invalid %s: %s' % (key, value))
     value = value.lower()
+    if preference == 0 and value == '.':
+        return value
     dnlabels = value.split('.')
     for label in dnlabels[:-1]:
         if not label_is_valid(label):
@@ -80,10 +82,12 @@ def validate_uint32(self, key, value):
     return value
 
 
-def validate_preference(self, key, value):
+def validate_preference(self, key, value, exchange=None):
     value = int(value)
-    if value < 1 or value > 32767:
-        raise InvalidParameterError('Preference min 1 max 32767')
+    if (value == 0 and exchange == '.'):
+        return value
+    if (value < 1 or value > 32767):
+        raise InvalidParameterError('Preference min 1 max 32767 or 0 with exchange "."')
     return value
 
 


### PR DESCRIPTION
To allow NULL MX records it was necessary to extend the validate_args
method with the context of other fields.

According to RFC7505 a preference of 0 is allowed when the target is
only '.' and the same in the other direction.
That means that both fields need to be checked in such cases which
requires the context of the other field.

In the future this allows us to implement similar validations for other
record types.

Fixes #128