### PR TITLE
update actions

### DIFF
--- a/.github/workflows/release_dim.yml
+++ b/.github/workflows/release_dim.yml
@@ -38,14 +38,15 @@ jobs:
           name: dim-src-${{ steps.version.outputs.version }}.tar.gz
           path: dim-src-${{ steps.version.outputs.version }}.tar.gz
 
-  centos8:
+  el8:
     runs-on: ubuntu-latest
     needs: build
     container:
-      image: centos:centos8
+      image: oraclelinux:8
       env:
         _VERSION: ${{ needs.build.outputs.version }}
     steps:
+      - run: /bin/dnf install --assumeyes gcc python39-devel mariadb-devel git python39 rpm-build tar gzip
       - uses: actions/download-artifact@v2
         with:
           name: dim-src-${{ needs.build.outputs.version }}.tar.gz
@@ -53,8 +54,7 @@ jobs:
       - run: tar -xzf dim-src-${{ needs.build.outputs.version }}.tar.gz
         working-directory: /tmp
       - uses: actions/checkout@v2
-      - run: /bin/dnf install --assumeyes openldap-devel gcc python3-devel mariadb-devel git python3 rpm-build
-      - run: /bin/python3 -m venv /opt/dim/
+      - run: /bin/python3.9 -m venv /opt/dim/
       - run: /opt/dim/bin/pip3 install -r dim/requirements.txt
       - run: /opt/dim/bin/pip3 install ./dim
       - run: mkdir /opt/dim/doc/
@@ -75,6 +75,8 @@ jobs:
           License: MIT
 
           Source0: dim-%{version}.tar.gz
+
+          Requires: python39
 
           # don't strip debug symbols, else it will all come crashing down
           %define debug_package %{nil}
@@ -101,86 +103,11 @@ jobs:
           name: dim-${{ needs.build.outputs.version }}-1.el8.x86_64.rpm
           path: ~/rpmbuild/RPMS/x86_64/dim-${{ needs.build.outputs.version }}-1.el8.x86_64.rpm
 
-  centos7:
-    runs-on: ubuntu-latest
-    needs: build
-    container:
-      image: centos:centos7
-      env:
-        _VERSION: ${{ needs.build.outputs.version }}
-    steps:
-      - uses: actions/download-artifact@v2
-        with:
-          name: dim-src-${{ needs.build.outputs.version }}.tar.gz
-          path: /tmp/
-      - run: tar -xzf dim-src-${{ needs.build.outputs.version }}.tar.gz
-        working-directory: /tmp
-      - uses: actions/checkout@v2
-      - run: /bin/yum install --assumeyes openldap-devel gcc python36-devel mariadb-devel git python36 rpm-build
-      - run: /bin/python3.6 -m venv /opt/dim/
-      - run: /opt/dim/bin/pip3.6 install -r dim/requirements.txt
-      - run: /opt/dim/bin/pip3.6 install ./dim
-      - run: mkdir /opt/dim/doc/
-      - run: cp -r /tmp/dim-${{ needs.build.outputs.version }}/doc/_build/html/* /opt/dim/doc/
-      - run: /bin/tar --transform="s,^opt,dim-${_VERSION}/opt," -czf "/tmp/dim-bin.tar.gz" opt
-        working-directory: /
-      - run: mkdir -p ${HOME}/rpmbuild/SPECS
-      - run: mkdir -p ${HOME}/rpmbuild/SOURCES
-      - shell: sh
-        run: |
-          cat <<EOF > ${HOME}/rpmbuild/SPECS/dim.spec
-          Name:    dim
-          Version: ${_VERSION}
-          Release: 1.el7
-          Summary: DNS and IP management
-
-          Group: application/system
-          License: MIT
-
-          Source0: dim-%{version}.tar.gz
-
-          # don't strip debug symbols, else it will all come crashing down
-          %define debug_package %{nil}
-          %define __strip /bin/true
-          # stop trying to compile python files with old python version
-          %if 0%{?rhel}
-          %global __os_install_post    \
-              /usr/lib/rpm/redhat/brp-compress \
-              %{!?__debug_package:\
-              /usr/lib/rpm/redhat/brp-strip %{__strip} \
-              /usr/lib/rpm/redhat/brp-strip-comment-note %{__strip} %{__objdump} \
-              } \
-              /usr/lib/rpm/redhat/brp-strip-static-archive %{__strip} \
-              %{!?__jar_repack:/usr/lib/rpm/redhat/brp-java-repack-jars} \
-          %{nil}
-          %endif
-
-          %description
-          DNS and IP management
-
-          %prep
-          %setup -q #unpack tarball
-
-          %build
-
-          %install
-          cp -rfa * %{buildroot}
-
-          %files
-          /opt/*
-          EOF
-      - run: cp /tmp/dim-bin.tar.gz ${HOME}/rpmbuild/SOURCES/dim-${_VERSION}.tar.gz
-      - run: rpmbuild -ba ${HOME}/rpmbuild/SPECS/dim.spec
-      - uses: actions/upload-artifact@v2
-        with:
-          name: dim-${{ needs.build.outputs.version }}-1.el7.x86_64.rpm
-          path: ~/rpmbuild/RPMS/x86_64/dim-${{ needs.build.outputs.version }}-1.el7.x86_64.rpm
-
   debian:
     runs-on: ubuntu-latest
     needs: build
     container:
-      image: debian:10
+      image: debian:11
       env:
         _VERSION: ${{ needs.build.outputs.version }}
     steps:
@@ -204,8 +131,7 @@ jobs:
     needs:
       - build
       - debian
-      - centos8
-      - centos7
+      - el8
     steps:
       - uses: actions/checkout@v2
       - uses: actions/create-release@v1
@@ -223,9 +149,6 @@ jobs:
       - uses: actions/download-artifact@v2
         with:
           name: dim-${{ needs.build.outputs.version }}-1.el8.x86_64.rpm
-      - uses: actions/download-artifact@v2
-        with:
-          name: dim-${{ needs.build.outputs.version }}-1.el7.x86_64.rpm
       - uses: actions/download-artifact@v2
         with:
           name: python3-dim_${{ needs.build.outputs.version }}_all.deb
@@ -253,12 +176,4 @@ jobs:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: dim-${{ needs.build.outputs.version }}-1.el8.x86_64.rpm
           asset_name: dim-${{ needs.build.outputs.version }}-1.el8.x86_64.rpm
-          asset_content_type: application/octet-stream
-      - uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: dim-${{ needs.build.outputs.version }}-1.el7.x86_64.rpm
-          asset_name: dim-${{ needs.build.outputs.version }}-1.el7.x86_64.rpm
           asset_content_type: application/octet-stream

--- a/.github/workflows/release_dim_web.yml
+++ b/.github/workflows/release_dim_web.yml
@@ -13,7 +13,7 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.version }}
     container:
-      image: debian:10
+      image: debian:11
       env:
         _VERSION: ${{ needs.build.outputs.version }}
 
@@ -40,74 +40,11 @@ jobs:
           name: dim-web-src-${{ steps.version.outputs.version }}.tar.gz
           path: dim-web-src-${{ steps.version.outputs.version }}.tar.gz
 
-  centos7:
+  el8:
     runs-on: ubuntu-latest
     needs: build
     container:
-      image: centos:centos7
-      env:
-        _VERSION: ${{ needs.build.outputs.version }}
-    steps:
-      - run: mkdir -p ${HOME}/rpmbuild/SPECS
-      - run: mkdir -p ${HOME}/rpmbuild/SOURCES
-      - run: /bin/yum install --assumeyes epel-release
-      - run: /bin/yum install --assumeyes python36-devel python36 rpm-build python36-flask python36-xmltodict python36-requests
-      - uses: actions/download-artifact@v2
-        with:
-          name: dim-web-src-${{ needs.build.outputs.version }}.tar.gz
-          path: ~/rpmbuild/SOURCES/
-      - shell: sh
-        run: |
-          cat <<EOF > ${HOME}/rpmbuild/SPECS/dim-web.spec
-          Name:    python36-dim-web
-          Version: ${_VERSION}
-          Release: 1.el7
-          Summary: DNS and IP management python library
-
-          Group: application/system
-          License: MIT
-
-          Source0: dim-web-src-%{version}.tar.gz
-          BuildRequires: python36-devel
-          BuildRequires: python36-flask
-          BuildRequires: python36-xmltodict
-          BuildRequires: python36-requests
-          Requires: python36-flask
-          Requires: python36-xmltodict
-          Requires: python36-requests
-          Requires: python36
-
-          # don't strip debug symbols, else it will all come crashing down
-          %define debug_package %{nil}
-          %define __strip /bin/true
-
-          %description
-          DNS and IP management
-
-          %prep
-          %autosetup -p1 -n dim-web-%{version}
-
-          %build
-          %py3_build
-
-          %install
-          %py3_install
-
-          %files
-          %{python3_sitelib}/*
-          %{_datadir}/*
-          EOF
-      - run: rpmbuild -ba ${HOME}/rpmbuild/SPECS/dim-web.spec
-      - uses: actions/upload-artifact@v2
-        with:
-          name: python36-dim-web-${{ needs.build.outputs.version }}-1.el7.x86_64.rpm
-          path: ~/rpmbuild/RPMS/x86_64/python36-dim-web-${{ needs.build.outputs.version }}-1.el7.x86_64.rpm
-
-  centos8:
-    runs-on: ubuntu-latest
-    needs: build
-    container:
-      image: centos:centos8
+      image: oraclelinux:8
       env:
         _VERSION: ${{ needs.build.outputs.version }}
     steps:
@@ -170,7 +107,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     container:
-      image: debian:10
+      image: debian:11
       env:
         _VERSION: ${{ needs.build.outputs.version }}
     steps:
@@ -198,8 +135,7 @@ jobs:
     needs:
       - build
       - debian
-      - centos7
-      - centos8
+      - el8
     steps:
       - uses: actions/checkout@v2
       - uses: actions/create-release@v1

--- a/.github/workflows/release_dimclient.yml
+++ b/.github/workflows/release_dimclient.yml
@@ -28,7 +28,7 @@ jobs:
           name: dimclient-src-${{ steps.version.outputs.version }}.tar.gz
           path: dimclient-src-${{ steps.version.outputs.version }}.tar.gz
 
-  centos7:
+  el7:
     runs-on: ubuntu-latest
     needs: build
     container:
@@ -85,11 +85,11 @@ jobs:
           name: python36-dimclient-${{ needs.build.outputs.version }}-1.el7.x86_64.rpm
           path: ~/rpmbuild/RPMS/x86_64/python36-dimclient-${{ needs.build.outputs.version }}-1.el7.x86_64.rpm
 
-  centos8:
+  el8:
     runs-on: ubuntu-latest
     needs: build
     container:
-      image: centos:centos8
+      image: oraclelinux:8
       env:
         _VERSION: ${{ needs.build.outputs.version }}
     steps:
@@ -229,8 +229,8 @@ jobs:
     needs:
       - build
       - debian
-      - centos7
-      - centos8
+      - el7
+      - el8
       - fedora
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/release_ndcli.yml
+++ b/.github/workflows/release_ndcli.yml
@@ -54,7 +54,7 @@ jobs:
           _dimclient: ${{ steps.dimclient.outputs.version }}
           _version: ${{ steps.version.outputs.version }}
 
-  centos7:
+  el7:
     runs-on: ubuntu-latest
     needs: build
     container:
@@ -130,11 +130,11 @@ jobs:
           name: python36-ndcli-${{ needs.build.outputs.version }}-1.el7.x86_64.rpm
           path: ~/rpmbuild/RPMS/x86_64/python36-ndcli-${{ needs.build.outputs.version }}-1.el7.x86_64.rpm
 
-  centos8:
+  el8:
     runs-on: ubuntu-latest
     needs: build
     container:
-      image: centos:centos8
+      image: oraclelinux:8
       env:
         _VERSION: ${{ needs.build.outputs.version }}
         _DIMCLIENT: ${{ needs.build.outputs.dimclient }}
@@ -321,8 +321,8 @@ jobs:
     needs:
       - build
       - debian
-      - centos7
-      - centos8
+      - el7
+      - el8
       - fedora
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
* bump Python version required for dim/server to 3.9:
  * remove el7 and Debian 10 for dim (Python 3.6/3.7)
  * add Debian 11 for dim (Python 3.9)
  * use `python39` via appstream for el8


* switch container to `oraclelinux:8` as `centos8` is EOL
* remove build dependency on `openldap-dev`, as we're using `ldap3` now