### PR TITLE
actions/el8: make sure checkout works

### DIFF
--- a/.github/workflows/release_dimclient.yml
+++ b/.github/workflows/release_dimclient.yml
@@ -93,11 +93,10 @@ jobs:
       env:
         _VERSION: ${{ needs.build.outputs.version }}
     steps:
+      - run: /bin/dnf install --assumeyes python3-devel python3 rpm-build python3-dns tar gzip git
       - uses: actions/checkout@v2
       - run: mkdir -p ${HOME}/rpmbuild/SPECS
       - run: mkdir -p ${HOME}/rpmbuild/SOURCES
-      - run: /bin/dnf install --assumeyes epel-release
-      - run: /bin/dnf install --assumeyes python3-devel python3 rpm-build python3-dns
       - uses: actions/download-artifact@v2
         with:
           name: dimclient-src-${{ needs.build.outputs.version }}.tar.gz

--- a/.github/workflows/release_ndcli.yml
+++ b/.github/workflows/release_ndcli.yml
@@ -139,11 +139,11 @@ jobs:
         _VERSION: ${{ needs.build.outputs.version }}
         _DIMCLIENT: ${{ needs.build.outputs.dimclient }}
     steps:
+      - run: /bin/dnf install --assumeyes epel-release
+      - run: /bin/dnf install --assumeyes python3-devel python3 rpm-build python3-dns python3-dateutil tar gzip git
       - uses: actions/checkout@v2
       - run: mkdir -p ${HOME}/rpmbuild/SPECS
       - run: mkdir -p ${HOME}/rpmbuild/SOURCES
-      - run: /bin/dnf install --assumeyes epel-release
-      - run: /bin/dnf install --assumeyes python3-devel python3 rpm-build python3-dns python3-dateutil
       - run: |
           curl --location "https://github.com/${{ github.repository }}/releases/download/dimclient-${_DIMCLIENT}/python3-dimclient-${_DIMCLIENT}-1.el8.x86_64.rpm" > ./python3-dimclient-${_DIMCLIENT}-1.el8.x86_64.rpm
           rpm -i ./python3-dimclient-${_DIMCLIENT}-1.el8.x86_64.rpm


### PR DESCRIPTION
install git/tar to make sure checkout works in actions on el8

`oraclelinux:8` comes without tar/git by default, but either of those is required to get the git checkout via `actions/checkout@v2`.