### PR TITLE
mark bug as known failure

### DIFF
--- a/dim-testsuite/tests/allocator_test.py
+++ b/dim-testsuite/tests/allocator_test.py
@@ -1,4 +1,6 @@
 from tests.util import RPCTest
+from sqlalchemy.exc import IntegrityError
+import pytest
 
 
 def ips(d):
@@ -147,6 +149,7 @@ class AllocatorTest(RPCTest):
         self.r.subnet_set_priority('192.168.1.0/24', 1)
         assert self.r.ippool_get_ip('testpool')['ip'] == '192.168.1.1'
 
+    @pytest.mark.xfail(raises=IntegrityError, reason='https://github.com/1and1/dim/issues/205')
     def test_delegation_not_subnet(self):
         self.r.ipblock_create('10::/32', status='Container')
         self.r.ippool_create('pool')

--- a/dim/requirements-dev.txt
+++ b/dim/requirements-dev.txt
@@ -1,6 +1,5 @@
 nose~=1.3
 nose-ignore-docstring~=0.2
-click~=7.1
-pytest~=6.2
+pytest~=7.1
 pytest-cov~=3.0
 Sphinx~=4.4


### PR DESCRIPTION
mark error tracked in #205 as known failure,
this allows us to check for passing pytest,
in e.g. actions

see https://docs.pytest.org/en/7.1.x/how-to/skipping.html

also bump pytest, and remove dependency on click in dev