### PR TITLE
add support for showing history from all layer3domains

### DIFF
--- a/dim-testsuite/t/history-layer3domain.t
+++ b/dim-testsuite/t/history-layer3domain.t
@@ -20,6 +20,10 @@ $ ndcli history ipblock 10.0.0.0/8
 timestamp                  user  tool   originating_ip objclass name       action
 2022-02-03 12:53:08.686055 admin native 127.0.0.1      ipblock  10.0.0.0/8 created in layer3domain b
 2022-02-03 12:53:08.546129 admin native 127.0.0.1      ipblock  10.0.0.0/8 created in layer3domain a
+$ ndcli history ipblock 10.0.0.0/8 layer3domain all
+timestamp                  user  tool   originating_ip objclass name       action
+2022-02-03 12:53:08.686055 admin native 127.0.0.1      ipblock  10.0.0.0/8 created in layer3domain b
+2022-02-03 12:53:08.546129 admin native 127.0.0.1      ipblock  10.0.0.0/8 created in layer3domain a
 $ ndcli history ipblock 10.0.0.0/8 layer3domain a
 timestamp                  user  tool   originating_ip objclass name       action
 2022-02-03 12:53:08.546129 admin native 127.0.0.1      ipblock  10.0.0.0/8 created in layer3domain a

--- a/dim-testsuite/t/history-layer3domain.t
+++ b/dim-testsuite/t/history-layer3domain.t
@@ -27,3 +27,13 @@ timestamp                  user  tool   originating_ip objclass name       actio
 $ ndcli history ipblock 10.0.0.0/8 layer3domain a
 timestamp                  user  tool   originating_ip objclass name       action
 2022-02-03 12:53:08.546129 admin native 127.0.0.1      ipblock  10.0.0.0/8 created in layer3domain a
+$ ndcli history layer3domain all
+timestamp                  user  tool   originating_ip objclass     name    action
+2022-03-18 14:56:00.825054 admin native 127.0.0.1      layer3domain b       created
+2022-03-18 14:56:00.612569 admin native 127.0.0.1      layer3domain a       created
+2022-03-18 14:56:00.207050 admin native 127.0.0.1      layer3domain two     deleted
+2022-03-18 14:55:59.991345 admin native 127.0.0.1      layer3domain two     set_attr rd=22:22
+2022-03-18 14:55:59.787253 admin native 127.0.0.1      layer3domain two     set_attr comment=c
+2022-03-18 14:55:59.575115 admin native 127.0.0.1      layer3domain two     created
+2022-03-18 14:55:59.573743 admin native 127.0.0.1      layer3domain two     set_attr rd=2:2
+2022-03-18 14:55:33.025375 local native                layer3domain default created

--- a/dim/dim/rpc.py
+++ b/dim/dim/rpc.py
@@ -2942,14 +2942,14 @@ class RPC(object):
         return hs.execute(limit, begin, end, incl=['layer3domain'])
 
     @readonly
-    def history_ipblock(self, ipblock, layer3domain, limit=None, begin=None, end=None):
+    def history_ipblock(self, ipblock, layer3domain=None, limit=None, begin=None, end=None):
         ip = parse_ip(ipblock)
         hs = HistorySelect()
         query = hs.add_select(Ipblock)
         query = query.where(hs.c.address == ip.address) \
             .where(hs.c.prefix == ip.prefix) \
             .where(hs.c.version == ip.version)
-        if layer3domain is not None:
+        if layer3domain is not None and layer3domain != 'all':
             layer3domain = _get_layer3domain_arg(layer3domain)
             query.where(hs.c.layer3domain == layer3domain.name)
         return hs.execute(limit, begin, end, incl=['layer3domain'])

--- a/dim/dim/rpc.py
+++ b/dim/dim/rpc.py
@@ -2963,7 +2963,9 @@ class RPC(object):
     @readonly
     def history_layer3domain(self, name, limit=None, begin=None, end=None):
         hs = HistorySelect()
-        hs.add_select(Layer3Domain).where(hs.c.name == name)
+        query = hs.add_select(Layer3Domain)
+        if name is not None and name != 'all':
+            query.where(hs.c.name == name)
         return hs.execute(limit, begin, end)
 
     @readonly

--- a/ndcli/dimcli/__init__.py
+++ b/ndcli/dimcli/__init__.py
@@ -2880,13 +2880,16 @@ delegation).''')
         self.client.output_delete(args.output)
 
 
-def register_history(htype, cmd_args, arg_meta, f, fargs):
+def register_history(htype, cmd_args, arg_meta: str, f, fargs, layer3domain_option: bool = False):
     def _get_history(self, args):
         func = getattr(self.client, f)
         fargs_l = fargs(args)
         options = OptionDict(limit=int(args.limit),
                              begin=_local2utc(args.get('begin')),
                              end=_local2utc(args.get('end')))
+        # add layer3domain option only if the history function supports it
+        if layer3domain_option:
+            options['layer3domain'] = args.get('layer3domain')
         columns = ['timestamp', {},
                    'user', {},
                    'tool', {},
@@ -2935,7 +2938,7 @@ register_history('user-groups', arg_meta='groups', cmd_args=(),
 register_history('pool', arg_meta='POOL', cmd_args=(Argument('poolname', completions=complete_allocate_poolname), ),
                  f='history_ippool', fargs=lambda args: [args.poolname])
 register_history('ipblock', arg_meta='IPBLOCK', cmd_args=(Argument('ipblock'), layer3domain_group),
-                 f='history_ipblock', fargs=lambda args: [args.ipblock, args.layer3domain])
+                 f='history_ipblock', fargs=lambda args: [args.ipblock], layer3domain_option=True)
 register_history('registrar-account', arg_meta='REGISTRAR_ACCOUNT', cmd_args=(registrar_account_arg, ),
                  f='history_registrar_account', fargs=lambda args: [args.registrar_account])
 register_history('layer3domain', arg_meta='LAYER3DOMAIN', cmd_args=(layer3domain_arg, ),

--- a/ndcli/dimcli/__init__.py
+++ b/ndcli/dimcli/__init__.py
@@ -2889,7 +2889,7 @@ def register_history(htype, cmd_args, arg_meta: str, f, fargs, layer3domain_opti
                              end=_local2utc(args.get('end')))
         # add layer3domain option only if the history function supports it
         if layer3domain_option:
-            options['layer3domain'] = args.get('layer3domain')
+            options['layer3domain'] = get_layer3domain(args.layer3domain)
         columns = ['timestamp', {},
                    'user', {},
                    'tool', {},


### PR DESCRIPTION
fix regression introduced in #188:
make layer3domain parameter for `history_ipblock()` optional so it works with older versions of ndcli

additionally:
* use user's configured layer3domain for `ndcli history ipblock` by default
* add support for `all` keyword  as value for layer3domain to show history from all l3ds for both `ndcli history ipblock` and `ndcli history layer3domain` commands