### PR TITLE
ndcli: add weak dependency on bash-completion

### DIFF
--- a/.github/workflows/release_ndcli.yml
+++ b/.github/workflows/release_ndcli.yml
@@ -96,6 +96,7 @@ jobs:
           Requires: python36-dimclient
           Requires: python36-dns
           Requires: python36
+          Suggests: bash-completion
 
           # don't strip debug symbols, else it will all come crashing down
           %define debug_package %{nil}
@@ -172,6 +173,7 @@ jobs:
           Requires: python3-dateutil
           Requires: python3-dns
           Requires: python3
+          Suggests: bash-completion
 
           # don't strip debug symbols, else it will all come crashing down
           %define debug_package %{nil}

--- a/packaging/debian/ndcli/debian/control
+++ b/packaging/debian/ndcli/debian/control
@@ -11,5 +11,6 @@ Depends: ${misc:Depends}, ${python3:Depends}
 Provides: python3-dimcli, python3-ndcli
 Replaces: python3-ndcli
 Conflicts: python3-ndcli
+Suggests: bash-completion
 Description: DNS and IP management CLI client
 


### PR DESCRIPTION
add `bash-completion` as a weak dependency for the ndcli packages

adding as weak dependency to not depend on `bash` itself

resolves #226