### PR TITLE
dim-web: fix searching for ips

### DIFF
--- a/dim-web/src/app/ip-pools/components/IpPoolsSearchView.vue
+++ b/dim-web/src/app/ip-pools/components/IpPoolsSearchView.vue
@@ -145,7 +145,7 @@
 
         if (foundIPv4 != null) {
           params.cidr = this.pattern;
-          this.jsonRpc('ipblock_get_attrs', [this.pattern], (response) => {
+          this.jsonRpc('ipblock_get_attrs', [this.pattern, {layer3domain: this.$config.DEFAULT_LAYER3DOMAIN}], (response) => {
             if (response.data.result) {
               this.pools_count = 1;
               this.max_page = Math.ceil(this.pools_count / this.page_size);
@@ -161,7 +161,7 @@
             }
           }, true);
         } else if (foundIPv6 != null) {
-          this.jsonRpc('ipblock_get_attrs', [this.pattern], (response) => {
+          this.jsonRpc('ipblock_get_attrs', [this.pattern, {layer3domain: this.$config.DEFAULT_LAYER3DOMAIN}], (response) => {
             if (response.data.result) {
               this.pools_count = 1;
               this.max_page = Math.ceil(this.pools_count / this.page_size);


### PR DESCRIPTION
Make dim-web set the layer3domain to its default when searching for IPs within IP Pools.

This makes search possible with multiple layer3domains in DIM, but restricts to the default layer3domain, as with the other functionality in DIM web.