### PR TITLE
rpc: fix freeing free ip

### DIFF
--- a/dim-testsuite/tests/ipblock_test.py
+++ b/dim-testsuite/tests/ipblock_test.py
@@ -119,6 +119,11 @@ class IpblockTest(RPCTest):
         assert self.r.ip_free('12.0.0.0') == -1
         assert self.r.ip_free('12.0.0.0', reserved=True) == 1
         assert self.r.ipblock_get_attrs('12.0.0.0')['status'] == 'Available'
+        # test with multiple layer3domains
+        self.r.layer3domain_create('two', 'dummy')
+        self.r.ip_mark('12.0.0.6', layer3domain='default')
+        assert self.r.ip_free('12.0.0.6', layer3domain='default') == 1
+        assert self.r.ip_free('12.0.0.6', layer3domain='default') == 0
 
     def test_attrs(self):
         self.r.ipblock_create('12.0.0.0/24', attributes={'team': '1'})

--- a/dim/dim/rpc.py
+++ b/dim/dim/rpc.py
@@ -619,7 +619,7 @@ class RPC(object):
             pool = get_pool(pool)
         check_ip(ip, layer3domain, options)
         block = Ipblock.query_ip(ip, layer3domain).first()
-        self._can_change_ip(block or ip, pool=pool)
+        self._can_change_ip(block or ip, pool=pool, layer3domain=layer3domain)
         freed = None
         if block:
             if block.status.name == 'Reserved' and not reserved:


### PR DESCRIPTION
fix permission check by passing the layer3domain as well as pool,
as it's possible to set either for `ip_free()`

add pytest to verify it's working with multiple layer3domains