### PR TITLE
dim - better cleanup when moving pools with small subnets

### DIFF
--- a/dim-testsuite/t/pool-modify-layer3domain.t
+++ b/dim-testsuite/t/pool-modify-layer3domain.t
@@ -28,11 +28,17 @@ INFO - Creating RR 1 PTR a.t. in zone 5.0.10.in-addr.arpa
 
 $ ndcli create pool b layer3domain a
 $ ndcli modify pool b add subnet 10.0.5.64/28
-INFO - Created subnet 10.0.5.0/28 in layer3domain a
-$ ndcli create rr a.t. a 10.0.5.65
+INFO - Created subnet 10.0.5.64/28 in layer3domain a
+$ ndcli create rr b.t. a 10.0.5.65
 INFO - Marked IP 10.0.5.65 from layer3domain a as static
 INFO - Creating RR b A 10.0.5.65 in zone t
 INFO - Creating RR 65 PTR b.t. in zone 5.0.10.in-addr.arpa
+
+$ ndcli list ips 10.0.5.0/24 status used
+INFO - Result for list ips 10.0.5.0/24
+ip        status ptr_target comment
+10.0.5.1  Static a.t.
+10.0.5.65 Static b.t.
 
 $ ndcli modify pool a set layer3domain b
 INFO - Changing subnet 10.0.5.0/28 to new parent 10.0.0.0/8 in layer3domain b
@@ -40,24 +46,36 @@ INFO - Creating view b in zone 5.0.10.in-addr.arpa without profile
 INFO - Changing child 10.0.5.0 of subnet 10.0.5.0/28 to layer3domain b
 INFO - Changing child 10.0.5.1 of subnet 10.0.5.0/28 to layer3domain b
 INFO - Deleting RR 1 PTR a.t. from zone 5.0.10.in-addr.arpa view a
+INFO - Creating RR 1 PTR a.t. comment None in zone 5.0.10.in-addr.arpa view b
 INFO - Changing child 10.0.5.15 of subnet 10.0.5.0/28 to layer3domain b
-WARNING - Deleting view a from zone 5.0.10.in-addr.arpa failed
+WARNING - Zone 5.0.10.in-addr.arpa view a was not deleted: The view a of the zone 5.0.10.in-addr.arpa is not empty.
+
+# ensure that reverse zone was not removed
+$ ndcli list ips 10.0.5.0/24 status used
+INFO - Result for list ips 10.0.5.0/24
+ip        status ptr_target comment layer3domain
+10.0.5.1  Static a.t.               b
+10.0.5.65 Static b.t.               a
+$ ndcli list zone 5.0.10.in-addr.arpa views
+name
+a
+b
 
 $ ndcli modify pool b set layer3domain b
 INFO - Changing subnet 10.0.5.64/28 to new parent 10.0.0.0/8 in layer3domain b
 INFO - Changing child 10.0.5.64 of subnet 10.0.5.64/28 to layer3domain b
 INFO - Changing child 10.0.5.65 of subnet 10.0.5.64/28 to layer3domain b
 INFO - Deleting RR 65 PTR b.t. from zone 5.0.10.in-addr.arpa view a
+INFO - Creating RR 65 PTR b.t. comment None in zone 5.0.10.in-addr.arpa view b
 INFO - Changing child 10.0.5.79 of subnet 10.0.5.64/28 to layer3domain b
 INFO - Deleting view a from zone 5.0.10.in-addr.arpa
-
 
 $ ndcli modify pool a remove subnet 10.0.5.0/28 -f -c -q
 $ ndcli delete pool a
 $ ndcli modify pool b remove subnet 10.0.5.64/28 -f -c -q
 $ ndcli delete pool b
 
-$ndcli delete zone t -f -c -q
+$ ndcli delete zone t -c -q
 
 $ ndcli delete output a
 $ ndcli delete output b

--- a/dim-testsuite/t/pool_change_layer3domain.t
+++ b/dim-testsuite/t/pool_change_layer3domain.t
@@ -219,16 +219,13 @@ record zone                ttl   type value
     66 5.0.10.in-addr.arpa       PTR  b.t.
 $ ndcli history ipblock 10.0.5.0/24
 timestamp                  user  tool   originating_ip objclass name        action
-2022-03-31 15:17:59.536249 admin native 127.0.0.1      ipblock  10.0.5.0/24 set_attr layer3domain=b in layer3domain b
-2022-03-31 15:17:59.523732 admin native 127.0.0.1      ipblock  10.0.5.0/24 set_attr layer3domain=a in layer3domain a
-2022-03-31 15:17:59.476550 admin native 127.0.0.1      ipblock  10.0.5.0/24 set_attr layer3domain=b in layer3domain b
-2022-03-31 15:17:58.704790 admin native 127.0.0.1      ipblock  10.0.5.0/24 set_attr layer3domain=a in layer3domain a
-2022-03-31 15:17:58.692130 admin native 127.0.0.1      ipblock  10.0.5.0/24 set_attr layer3domain=b in layer3domain b
-2022-03-31 15:17:58.643961 admin native 127.0.0.1      ipblock  10.0.5.0/24 set_attr layer3domain=a in layer3domain a
-2022-03-31 15:17:58.489071 admin native 127.0.0.1      ipblock  10.0.5.0/24 set_attr layer3domain=b in layer3domain b
-2022-03-31 15:17:58.470090 admin native 127.0.0.1      ipblock  10.0.5.0/24 set_attr layer3domain=a in layer3domain a
-2022-03-31 15:17:58.418779 admin native 127.0.0.1      ipblock  10.0.5.0/24 set_attr layer3domain=b in layer3domain b
-2022-03-31 15:17:57.529218 admin native 127.0.0.1      ipblock  10.0.5.0/24 deleted in layer3domain b
+2022-05-06 12:41:19.157366 admin native 127.0.0.1      ipblock  10.0.5.0/24 set_attr layer3domain=b in layer3domain b
+2022-05-06 12:41:18.394729 admin native 127.0.0.1      ipblock  10.0.5.0/24 set_attr layer3domain=a in layer3domain a
+2022-05-06 12:41:18.165002 admin native 127.0.0.1      ipblock  10.0.5.0/24 set_attr layer3domain=b in layer3domain b
+2022-05-06 12:41:17.190089 admin native 127.0.0.1      ipblock  10.0.5.0/24 deleted in layer3domain b
+2022-05-06 12:41:16.965841 admin native 127.0.0.1      ipblock  10.0.5.0/24 created in layer3domain b
+2022-05-06 12:41:16.084417 admin native 127.0.0.1      ipblock  10.0.5.0/24 set_attr pool=a in layer3domain a
+2022-05-06 12:41:16.075188 admin native 127.0.0.1      ipblock  10.0.5.0/24 created in layer3domain a
 $ ndcli modify zone-group b add zone 5.0.10.in-addr.arpa view b
 $ ndcli modify zone-group b add zone 0.23.10.in-addr.arpa view b
 $ ndcli list outputs -t


### PR DESCRIPTION
The function _delete_reverse_zones expected the subnet to be deleted
already. This lead to many reverse zones not being deleted or the
transaction being blocked altogether.

By forcing the deletion and working with a copy of the actual Subnet
object the deletion now goes through without problems.

Fixes #233