### PR TITLE
dim,ndcli - add new permission to set attributes on pools

### DIFF
--- a/dim-testsuite/t/pool-set-attrs.t
+++ b/dim-testsuite/t/pool-set-attrs.t
@@ -1,0 +1,41 @@
+$ ndcli login -u withperm -p p
+$ ndcli login -u withoutperm -p p
+$ ndcli login -u networkadmin -p p
+$ ndcli create pool testpool
+$ ndcli modify pool testpool set attrs 'donottouch:true'
+$ ndcli create user-group withperm
+$ ndcli modify user-group withperm add user withperm
+$ ndcli modify user-group withperm grant attr 'withperm.' testpool
+$ ndcli create user-group withoutperm
+$ ndcli modify user-group withoutperm add user withoutperm
+$ ndcli create user-group networkadmin
+$ ndcli modify user-group networkadmin add user networkadmin
+$ ndcli modify user-group networkadmin grant network_admin
+
+$ ndcli modify pool testpool set attrs 'withperm.success:true' -u withperm
+$ ndcli show pool testpool -u withperm
+created:2022-05-11 16:49:06
+donottouch:true
+layer3domain:default
+modified:2022-05-11 16:49:07
+modified_by:withperm
+name:testpool
+withperm.success:true
+$ ndcli modify pool testpool set attrs 'donottouch:false' -u withperm
+ERROR - Permission denied (can_set_attribute testpool donottouch)
+$ ndcli modify user-group withperm grant attr 'fromnetworkadmin.' testpool -u networkadmin
+$ ndcli modify pool testpool set attrs 'fromnetworkadmin.success:true' -u withperm
+$ ndcli show pool testpool -u withperm
+created:2022-05-11 16:49:06
+donottouch:true
+fromnetworkadmin.success:true
+layer3domain:default
+modified:2022-05-11 16:49:07
+modified_by:withperm
+name:testpool
+withperm.success:true
+$ ndcli modify pool testpool set attrs 'thisfails:does it?' -u withoutperm
+ERROR - Permission denied (can_set_attribute testpool thisfails)
+$ ndcli list pools -a name,withperm.success
+name withperm.success
+testpool true

--- a/dim/dim/models/rights.py
+++ b/dim/dim/models/rights.py
@@ -207,7 +207,7 @@ class User(db.Model):
 
     @permission
     def can_set_attribute(self, pool, attr):
-        if self.can_modify_pool_attributes():
+        if self.has_any_access([('network_admin', None)]):
             return True
         return Group.query.filter(Group.users.any(id=self.id)). \
             join(GroupRight). \

--- a/dim/dim/models/rights.py
+++ b/dim/dim/models/rights.py
@@ -1,6 +1,6 @@
 from contextlib import wraps
 
-from sqlalchemy import Column, Integer, BigInteger, Boolean, String, Text, ForeignKey, UniqueConstraint, or_
+from sqlalchemy import Column, Integer, BigInteger, Boolean, String, Text, ForeignKey, UniqueConstraint, or_, literal
 from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.orm import relationship, backref
 
@@ -111,7 +111,7 @@ class AccessRight(db.Model):
 
     groups = association_proxy('grouprights', 'group')
 
-    grantable_by_network_admin = ['allocate']
+    grantable_by_network_admin = ['allocate', 'attr']
     grantable_by_dns_admin = [
         'dns_update_agent',
         'zone_create',
@@ -204,6 +204,16 @@ class User(db.Model):
                 class_name = dict(Pool='Ippool').get(obj.__class__.__name__, obj.__class__.__name__)
                 anylist.append(Group.rights.any(access=access, object_class=class_name, object_id=obj.id))
         return Group.query.filter(Group.users.any(id=self.id)).filter(or_(*anylist)).count() != 0
+
+    @permission
+    def can_set_attribute(self, pool, attr):
+        return Group.query.filter(Group.users.any(id=self.id)). \
+            join(GroupRight). \
+            join(AccessRight).filter(
+                AccessRight.object_id == pool.id,
+                AccessRight.object_class == 'Ippool',
+                literal('attr.' + attr).like(AccessRight.access + '%')).count() != 0
+
 
     @property
     def is_super_admin(self):

--- a/dim/dim/models/rights.py
+++ b/dim/dim/models/rights.py
@@ -207,6 +207,8 @@ class User(db.Model):
 
     @permission
     def can_set_attribute(self, pool, attr):
+        if self.can_modify_pool_attributes():
+            return True
         return Group.query.filter(Group.users.any(id=self.id)). \
             join(GroupRight). \
             join(AccessRight).filter(

--- a/dim/dim/models/rights.py
+++ b/dim/dim/models/rights.py
@@ -207,7 +207,9 @@ class User(db.Model):
 
     @permission
     def can_set_attribute(self, pool, attr):
-        if self.has_any_access([('network_admin', None)]):
+        is_network_admin = self.has_any_access([('network_admin', None)])
+        is_dns_admin = self.has_any_access([('dns_admin', None)])
+        if is_network_admin or is_dns_admin:
             return True
         return Group.query.filter(Group.users.any(id=self.id)). \
             join(GroupRight). \

--- a/ndcli/dimcli/__init__.py
+++ b/ndcli/dimcli/__init__.py
@@ -1832,6 +1832,9 @@ delegation).''')
         'dns_admin': dict(desc='full access to all zones'),
         'dns_update_agent': dict(desc='ability to delete output updates'),
         'zone_create': dict(desc='ability to create forward zones'),
+        'attr': dict(desc='set attributes on pools with the specified prefix',
+                arguments=(Argument('prefix'), Argument('poolname', completions=complete_poolname), ),
+                extra=lambda args: ([args.prefix, args.poolname], )),
         'allocate':
             dict(desc='modify the contents of subnets from POOLNAME',
                  arguments=(Argument('poolname', completions=complete_poolname), ),


### PR DESCRIPTION
Extend the permission system with a new permission to allow network
admins to grant the permission to set attributes on pools.

The permission is bound to a prefix so that attributes can be
namespaced and assigned to different groups for usage.