### PR TITLE
fix #238 - do not allow A/AAAA/PTR records in zone-profiles

### DIFF
--- a/dim-testsuite/tests/dns_test.py
+++ b/dim-testsuite/tests/dns_test.py
@@ -111,6 +111,10 @@ class ZoneTest(RPCTest):
         assert rrs(self.r.rr_list('*test.com.')) == rrs(
             [('a', 'test.com', 'TXT', '"something"'),
              ('@', 'test.com', 'NS', 'whatever.com.')])
+        with raises(InvalidParameterError):
+            self.r.rr_create(name='foo.profile.', type='A', ip='127.0.0.1', profile=True)
+        with raises(InvalidParameterError):
+            self.r.rr_create(name='foo.profile.', type='AAAA', ip='::1', profile=True)
 
     def test_list_zone(self):
         self.r.zone_create('some.domain', soa_attributes=dict(primary='ns01.company.com.', mail='dnsadmin.company.com.'))
@@ -421,15 +425,15 @@ class RR(RPCTest):
 
     def test_email(self):
         self.r.zone_create('test.com')
-        self.r.zone_set_soa_attrs('test.com', {'mail': 'first\.last.test.com.'})
-        assert " first\.last.test.com. " in self.r.zone_dump('test.com')
+        self.r.zone_set_soa_attrs('test.com', {'mail': 'first.last.test.com.'})
+        assert " first.last.test.com. " in self.r.zone_dump('test.com')
 
     def test_create_revzone(self):
         self.r.rr_create(ip='12.0.0.1', type='PTR', ptrdname='test.com.', create_linked=False, create_revzone=True)
 
     def test_create_rr_rp(self):
         self.r.zone_create('test.com')
-        self.r.rr_create(name='a.test.com.', type='RP', mbox='john\.doe.example.com.', txtdname='test.com.')
+        self.r.rr_create(name='a.test.com.', type='RP', mbox='john.doe.example.com.', txtdname='test.com.')
 
     def test_create_rr_cert(self):
         self.r.zone_create('test.com')

--- a/dim/dim/rpc.py
+++ b/dim/dim/rpc.py
@@ -3270,6 +3270,8 @@ class RPC(object):
             return reverse_zone, created_ptr
 
         if type in ('A', 'AAAA', 'PTR'):
+            if profile:
+                raise InvalidParameterError('Cannot add PTR records to zone profiles.')
             view = kwargs.pop('view', None)
             overwrite_a = kwargs.pop('overwrite_a', False)
             overwrite_ptr = kwargs.pop('overwrite_ptr', False)
@@ -3277,8 +3279,6 @@ class RPC(object):
             forward_zone = reverse_zone = None
             created_ptr = False
             if type == 'PTR':
-                if profile:
-                    raise InvalidParameterError('Cannot add PTR records to zone profiles.')
                 reverse_zone, created_ptr = create_reverse()
                 if create_linked:
                     forward_zone = create_forward()

--- a/ndcli/dimcli/__init__.py
+++ b/ndcli/dimcli/__init__.py
@@ -2344,7 +2344,7 @@ delegation).''')
                      description='Modifies a ' + rr.upper() + ' resource record.',
                      *show_rr_options)\
                     (_make_modify_rr(rr_type=rr.upper(), params=params))
-        if rr != 'ptr':
+        if rr not in ('ptr', 'a', 'aaaa'):
             cmd.register('modify zone-profile create rr ' + rr,
                          description='Adds a ' + rr.upper() + ' resource record to PROFILENAME.',
                          *create_profile_rr_options)\


### PR DESCRIPTION
When zone-profiles are copied to become a real zone, the A and AAAA
records must belong to layer3domain.

It is not feasible to specify on the layer3domain each A/AAAA record
needs to go to when ndcli create zone is executed.

To avoid this problem, zone-profiles must not contain A or AAAA records.