### PR TITLE
Allow to configure default TTL for created records using .ndclirc

### DIFF
--- a/ndcli/dimcli/__init__.py
+++ b/ndcli/dimcli/__init__.py
@@ -572,6 +572,10 @@ def _make_create_rr(rr_type, params, profile, zonearg, create_linked=None):
             options.set_if(overwrite=args.overwrite)
         if rr_type != 'PTR' and '.' in args.name and not args.name.endswith('.'):
             self.warning("The left hand side of this record contains '.'. This will probably not do what you expect it to do.")
+
+        if "ttl" not in options and "default-ttl" in config:
+            options["ttl"] = config["default-ttl"]
+
         result = self.client.rr_create(**options)
         _print_messages(result)
     return create_simple_rr


### PR DESCRIPTION
I want to create records with a configurable default TTL (specified in the .ndclirc file) without having to change the global TTL of the zone.

Therefore, this Pull Request implements a new option named `default-ttl` in the .ndclirc file. Specifying this option results in setting the `ttl` for created resource records if not specified otherwise while creating the record.

For example, specifying `default-ttl = 300` in the config and creating a new record with `ndcli create rr example.com. a 1.2.3.4` would result in specifying the TTL just like creating the record with `ndcli create rr example.com. ttl 300 a 1.2.3.4`.

It is still possible to specify a different TTL while creating the record by explicitly providing the TTL like before (i.e. `ndcli create rr example.com. ttl 60 1.2.3.4`).

Not configuring the `default-ttl` option in the .ndclirc just keeps the current behavior of not specifying the TTL for created records. So, this PR should not break anything.