### PR TITLE
Add exact-match option to rr_list and ndcli

### DIFF
--- a/dim-testsuite/tests/dns_test.py
+++ b/dim-testsuite/tests/dns_test.py
@@ -403,6 +403,16 @@ class RR(RPCTest):
         with raises(InvalidParameterError):
             self.r.rr_create(name='d.test.com.', type='MX', preference=10, exchange='a.test.com.')
 
+    def test_rr_list_exact(self):
+        self.r.zone_create('test.com')
+        self.r.rr_create(name='*.test.com.', type='A', ip='12.0.0.1')
+        self.r.rr_create(name='a.test.com.', type='A', ip='12.0.0.2')
+        wildcard = rrs(self.r.rr_list(pattern='*.test.com.'))
+        assert ('*', 'test.com', 'A', '12.0.0.1') in wildcard
+        assert ('a', 'test.com', 'A', '12.0.0.2') in wildcard
+        assert rrs(self.r.rr_list(pattern='*.test.com.', exact=True)) == rrs([
+            ('*', 'test.com', 'A', '12.0.0.1')])
+
     def test_create_cname_2(self):
         # ND-100
         self.r.zone_create('test.com')

--- a/dim/CHANGES
+++ b/dim/CHANGES
@@ -6,6 +6,7 @@
 * fix missing check if pool is already in target layer3domain (#232)
 * fix missing check to avoid creating A or AAAA records in zone profiles (#238)
 * update dependencies (#248)
+* add exact match option to :func:`rr_list`/``rr_list2`` to allow listing literal wildcard records (#298)
 
 5.0.1
 -----
@@ -428,4 +429,3 @@ API Changes:
     * *vlan* option for :func:`ippool_create`, :func:`ippool_set_vlan`
     * *priority* parameter for :func:`subnet_set_priority`
     * *prefix*, *maxsplit* parameters for :func:`ippool_get_delegation`
-

--- a/dim/doc/api.rst
+++ b/dim/doc/api.rst
@@ -1179,6 +1179,7 @@ RR Functions
    - *limit*: limit the amount of results
    - *offset*: skip the first *offset* results
    - *pattern* (string): pattern to match against the RR name or IP address. A relative pattern will be converted into an absolute one.
+   - *exact* (boolean): if true, the *pattern* is treated as a literal RR name instead of a wildcard/glob
    - *type* (string): filter by RR type
    - *zone* (string): filter by RR zone
    - *view* (string): :ref:`view_option`

--- a/ndcli/CHANGES
+++ b/ndcli/CHANGES
@@ -1,6 +1,7 @@
 5.0.4
 -----
 * fix TXT records when importing zone (#292)
+* add ``--exact`` switch to ``list rrs`` for literal wildcard records (#298)
 
 5.0.3
 -----

--- a/ndcli/dimcli/__init__.py
+++ b/ndcli/dimcli/__init__.py
@@ -2541,6 +2541,7 @@ delegation).''')
                   Argument('wildcard'),
                   rr_type_arg,
                   layer3domain_group,
+                  Option(None, 'exact', action='store_true', help='match only exact record names'),
                   script_option)
     def list_rrs(self, args):
         '''
@@ -2549,7 +2550,8 @@ delegation).''')
         options = OptionDict(pattern=args.wildcard)
         # do not use get_layer3domain() as CNAMEs etc. do not have a layer3domain
         options.set_if(type=args.type,
-                       layer3domain=args.get('layer3domain'))
+                       layer3domain=args.get('layer3domain'),
+                       exact=args.exact)
         logger.info("Result for list rrs %s" % args.wildcard)
         rrs = self.client.rr_list(**options)
         _print_table(['record', {},

--- a/ndcli/tests/dimcli_test.py
+++ b/ndcli/tests/dimcli_test.py
@@ -228,6 +228,18 @@ def test_create_rr_cname():
     assert ndcli('delete zone test.com --cleanup').ok
 
 
+def test_list_rrs_exact():
+    assert ndcli('create zone test.com').ok
+    assert ndcli('create rr *.test.com. a 12.0.0.1').ok
+    assert ndcli('create rr a.test.com. a 12.0.0.2').ok
+    wildcard = nosoa(ndcli('list rrs *.test.com. -H').table)
+    assert ['*', 'test.com', 'default', '', 'A', '12.0.0.1'] in wildcard
+    assert ['a', 'test.com', 'default', '', 'A', '12.0.0.2'] in wildcard
+    assert nosoa(ndcli('list rrs *.test.com. --exact -H').table) == [
+        ['*', 'test.com', 'default', '', 'A', '12.0.0.1']]
+    assert ndcli('delete zone test.com --cleanup').ok
+
+
 def test_show_rr():
     # ND-92
     assert ndcli('create zone test.com').ok


### PR DESCRIPTION
Adds an exact flag to both rr_list/rr_list2 and ndcli’s list rrs so literal wildcard records (e.g., *.example.com.) can be retrieved without treating the name as a glob. 

Updates the API docs and changelog entries, and adds regression tests on the DIM and ndcli sides to cover the new behavior. 

Fixes #298.