### PR TITLE
use OL9, and bump actions/checkout for pytests workflow

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -31,6 +31,8 @@ jobs:
           MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: 'yes'
         options: '--health-cmd="healthcheck.sh --su-mysql --connect --innodb_initialized" --health-interval=5s --health-timeout=2s --health-retries=4'
     steps:
+      - name: Enable CRB repository for MariaDB dependencies
+        run: /bin/dnf config-manager --set-enabled ol9_codeready_builder
       - name: Install dependencies
         run: /bin/dnf install --assumeyes gcc python3-devel mariadb-devel git python3 make tar gzip
       - name: Check out repository code

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install dependencies
         run: /bin/dnf install --assumeyes gcc python3-devel mariadb-devel git python3 make tar gzip
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Prepare virtual environment
         run: make install-test
         working-directory: dim-testsuite

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -20,7 +20,7 @@ jobs:
   pytest_dim:
     runs-on: ubuntu-latest
     container:
-      image: oraclelinux:8
+      image: oraclelinux:9
     services:
       mariadb:
         image: mariadb:10.11
@@ -32,7 +32,7 @@ jobs:
         options: '--health-cmd="healthcheck.sh --su-mysql --connect --innodb_initialized" --health-interval=5s --health-timeout=2s --health-retries=4'
     steps:
       - name: Install dependencies
-        run: /bin/dnf install --assumeyes gcc python39-devel mariadb-devel git python39 make tar gzip
+        run: /bin/dnf install --assumeyes gcc python3-devel mariadb-devel git python3 make tar gzip
       - name: Check out repository code
         uses: actions/checkout@v3
       - name: Prepare virtual environment


### PR DESCRIPTION
* Python 3.9 on Oracle Linux 8 is EOL, switch to pytest worflow to Oracle Linux 9 where Python 3.9 is still supported.

* Bump https://github.com/actions/checkout in the pytest workflow from `v3` to current latest `v6`