### PR TITLE
Update OBS repository path to official network:dim namespace

### DIFF
--- a/.github/workflows/release_ndcli.yml
+++ b/.github/workflows/release_ndcli.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Activate CRB for dependencies
         run: /bin/dnf config-manager --enable ol9_codeready_builder
       - name: Add DIM repository from OBS for dimclient
-        run: /bin/dnf config-manager --add-repo https://download.opensuse.org/repositories/home:/zeromind:/dim/RockyLinux_9/home:zeromind:dim.repo
+        run: /bin/dnf config-manager --add-repo https://download.opensuse.org/repositories/network:/dim/RockyLinux_9/network:dim.repo
         working-directory: /etc/yum.repos.d
       - name: Install dependencies
         run: /bin/dnf install --assumeyes python3-sphinx python3-dns python3-dimclient

--- a/dimclient/README.md
+++ b/dimclient/README.md
@@ -9,7 +9,7 @@ To use `dimclient`, install it in your Python environment.
 
 There are two options to do that:
 
-1. *Distribution packages:* Download and install a distribution-packaged package. There are packages for Linux distributions available at [openSUSE Build Service - home:zeromind:dim/dimclient](https://build.opensuse.org/package/show/home:zeromind:dim/dimclient).
+1. *Distribution packages:* Download and install a distribution-packaged package. There are packages for Linux distributions available at [openSUSE Build Service - network:dim/dimclient](https://build.opensuse.org/package/show/network:dim/dimclient).
    Note that distribution packages install the dimclient globally.
 2. *Python PIP:* [PyPI dimclient](https://pypi.org/project/dimclient/)
 

--- a/ndcli/README.md
+++ b/ndcli/README.md
@@ -8,7 +8,7 @@ To use `ndcli`, install it in your Python environment.
 
 There are two options to do that:
 
-1. **Distribution packages**: Download and install a distribution-packaged package. There are packages for Linux distributions available at [openSUSE Build Service - home:zeromind:dim/ndcli](https://build.opensuse.org/package/show/home:zeromind:dim/ndcli) (provides bash completion and man page).
+1. **Distribution packages**: Download and install a distribution-packaged package. There are packages for Linux distributions available at [openSUSE Build Service - network:dim/ndcli](https://build.opensuse.org/package/show/network:dim/ndcli) (provides bash completion and man page).
 2. **Python PIP**: [PyPI dimclient-cli](https://pypi.org/project/dimclient/) (does not provide bash completion or man page)
 
     ```sh


### PR DESCRIPTION
Migrate references to the openSUSE Build Service (OBS) repository from the personal home:zeromind:dim namespace to the official network:dim namespace. This keeps the release workflow and documentation aligned with the active repository location.

Co-authored-by: Gemini <gemini@google.com>