### PR TITLE
workflows: fix test execution in CI and correct DNAME test suite

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -32,7 +32,9 @@ jobs:
         options: '--health-cmd="healthcheck.sh --su-mysql --connect --innodb_initialized" --health-interval=5s --health-timeout=2s --health-retries=4'
     steps:
       - name: Enable CRB repository for MariaDB dependencies
-        run: /bin/dnf config-manager --set-enabled ol9_codeready_builder
+        run: |
+          /bin/dnf install --assumeyes dnf-plugins-core
+          /bin/dnf config-manager --set-enabled ol9_codeready_builder
       - name: Install dependencies
         run: /bin/dnf install --assumeyes gcc python3-devel mariadb-devel git python3 make tar gzip
       - name: Check out repository code

--- a/dim-testsuite/tests/dns_test.py
+++ b/dim-testsuite/tests/dns_test.py
@@ -623,8 +623,6 @@ class TXT(RPCTest):
 
     def test_dname_conflicts_with_other_records(self):
         """Test that DNAME cannot coexist with other records at same name"""
-        self.r.zone_create('test.com')
-        
         # Create A record first
         self.r.rr_create(name='conflict.test.com.', type='A', ip='1.2.3.4')
         
@@ -634,8 +632,6 @@ class TXT(RPCTest):
 
     def test_other_records_conflict_with_dname(self):
         """Test that other records cannot be created at same name as DNAME"""
-        self.r.zone_create('test.com')
-        
         # Create DNAME first
         self.r.rr_create(name='dept.test.com.', type='DNAME', target='dept.example.com.')
         
@@ -645,8 +641,6 @@ class TXT(RPCTest):
 
     def test_dname_subtree_conflict(self):
         """Test that records cannot be created under DNAME subtree"""
-        self.r.zone_create('test.com')
-        
         # Create DNAME first
         self.r.rr_create(name='dept.test.com.', type='DNAME', target='dept.example.com.')
         
@@ -656,8 +650,6 @@ class TXT(RPCTest):
 
     def test_dname_existing_subtree_conflict(self):
         """Test that DNAME cannot be created if records exist under the subtree"""
-        self.r.zone_create('test.com')
-        
         # Create record under subtree first
         self.r.rr_create(name='marketing.dept.test.com.', type='A', ip='1.2.3.4')
         

--- a/dim-testsuite/tests/util.py
+++ b/dim-testsuite/tests/util.py
@@ -8,11 +8,14 @@ from dim.models import clean_database, User, Group, AccessRight, Layer3Domain, I
 
 
 @contextmanager
-def raises(error):
+def raises(error, message=None):
     try:
         yield
-    except error:
-        pass
+    except error as e:
+        if message is not None:
+            err_msg = str(e)
+            if message not in err_msg:
+                raise AssertionError("Expected exception message containing '%s' but got '%s'" % (message, err_msg))
     except Exception as e:
         logging.exception(e)
         raise AssertionError("Expected exception %s but got %s" % (error.__name__, e.__class__.__name__))


### PR DESCRIPTION
- Install dnf-plugins-core first in Oracle Linux 9 container so that dnf config-manager is available.
- Support optional exception message verification in the raises() test helper.
- Remove redundant zone creation from DNAME tests to fix AlreadyExistsError.